### PR TITLE
Fixes #241 Dynamic Directives example

### DIFF
--- a/src/docs/guide/usage/directives.gdoc
+++ b/src/docs/guide/usage/directives.gdoc
@@ -54,7 +54,11 @@ h3. Dynamic Directives
 The asset-pipeline require directives also support the use of the Groovy Templates via the @GStringTemplateEngine@. This means you can use some conditional require situations based, for example, on the grails Environment.
 
 {code}
-//= require ${grails.util.Environment.currentEnvironment == 'development' ? 'ember.debug.js' : 'ember.prod.js'}
+//= require ${grails.util.Environment.currentEnvironment.toString() == 'DEVELOPMENT' ? 'ember.debug.js' : 'ember.prod.js'}
+{code}
+or
+{code}
+//= require ${grails.util.Environment.currentEnvironment == grails.util.Environment.DEVELOPMENT ? 'ember.debug.js' : 'ember.prod.js'}
 {code}
 
 {note}


### PR DESCRIPTION
The ternary condition in the dynamic directives example should be either grails.util.Environment.currentEnvironment.toString() == 'DEVELOPMENT' or grails.util.Environment.currentEnvironment == grails.util.Environment.DEVELOPMENT as the current example is not working in Grails 2.4.4