### PR TITLE
Pass enableSourceMaps config setting to AssetCompiler

### DIFF
--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -32,6 +32,7 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 	assetConfig.minifyOptions = config.grails.assets.minifyOptions
 	assetConfig.compileDir = "${basedir}/target/assets"
 	assetConfig.excludesGzip = config.grails.assets.excludesGzip
+    assetConfig.enableSourceMaps = config.grails.assets.enableSourceMaps
 
 	//Add Resolvers for Grails
 	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application','grails-app/assets'))


### PR DESCRIPTION
It doesn't look like the enableSourceMaps setting is actually sent along to the asset compiler. This change should get the setting down into the ClosureCompilerProcessor in asset-pipeline-core.