### PR TITLE
Relative path creation changed. 

### DIFF
--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -51,7 +51,7 @@ class AssetMethodTagLib {
             if(absolute && !conf.url){
                 return [grailsLinkGenerator.serverBaseURL, "$mapping/"].join('/')
             }
-            String relativePathToResource = (request.contextPath + "${request.contextPath?.endsWith('/') ? '' : '/'}$mapping/" )
+            String relativePathToResource = (grailsLinkGenerator.contextPath + "${grailsLinkGenerator.contextPath?.endsWith('/') ? '' : '/'}$mapping/" )
             return conf.url ?: relativePathToResource
         }
 

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -1,6 +1,7 @@
 package asset.pipeline.grails
 
 import grails.util.Environment
+import org.apache.commons.lang.StringUtils
 
 class AssetMethodTagLib {
 
@@ -51,7 +52,8 @@ class AssetMethodTagLib {
             if(absolute && !conf.url){
                 return [grailsLinkGenerator.serverBaseURL, "$mapping/"].join('/')
             }
-            String relativePathToResource = (grailsLinkGenerator.contextPath + "${grailsLinkGenerator.contextPath?.endsWith('/') ? '' : '/'}$mapping/" )
+            def contextPath = StringUtils.trimToEmpty(grailsLinkGenerator?.contextPath)
+            String relativePathToResource = (contextPath + "${contextPath?.endsWith('/') ? '' : '/'}$mapping/" )
             return conf.url ?: relativePathToResource
         }
 


### PR DESCRIPTION
We can use `grailsLinkGenerator` instead `request` to resolve `contextPath`.

Reason:
We use assets with Grails PageRenderer: `groovyPageRenderer.render template: '/rating/re7refresh', model: [changes: editor.re7Changes.flatten(), linkGenerator: grailsLinkGenerator]`
This has the consequence that PageRenderer creates a new GrailsWebRequest and the Request is null at `AssetMethodTagLib#assetUriRootPath()`