### PR TITLE
When dealing with multi module project where Grails application is a …

### DIFF
--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -35,7 +35,7 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
     assetConfig.enableSourceMaps = config.grails.assets.enableSourceMaps
 
 	//Add Resolvers for Grails
-	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application','grails-app/assets'))
+	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application',"${basedir}/grails-app/assets"))
 	// for(plugin in pluginManager.getAllPlugins()) {
 	// 	if(plugin instanceof org.codehaus.groovy.grails.plugins.BinaryGrailsPlugin) {
 	// 		def descriptorURI = plugin.binaryDescriptor.resource.URI


### PR DESCRIPTION
…child module path is not correct. Application resolver falls back to the Parent basedir instead of current module basedir thus missing the application assets when WAR packing.