### PR TITLE
grails.assets.enableDigest == false prevents file name digest insertion

### DIFF
--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -1,6 +1,5 @@
 package asset.pipeline.grails
 
-import grails.util.Environment
 import org.apache.commons.lang.StringUtils
 
 class AssetMethodTagLib {
@@ -18,21 +17,21 @@ class AssetMethodTagLib {
         def ignorePrefix = false
         def absolute = false
         if (attrs instanceof Map) {
-            
             src = attrs.src
             //unused
             ignorePrefix = attrs.containsKey('ignorePrefix')? attrs.ignorePrefix : false
             absolute = attrs.containsKey('absolute') ? attrs.absolute : false
         } else {
-            
             src = attrs
         }
-       
+
         def conf = grailsApplication.config.grails.assets
 
         def assetUrl = assetUriRootPath(grailsApplication, request, absolute)
 
-        if(conf.precompiled && src) {
+        def enableDigests = conf.containsKey('enableDigests') ? conf.enableDigests : true
+
+        if(conf.precompiled && src && enableDigests) {
             def realPath = conf.manifest.getProperty(src)
             if(realPath) {
                 return "${assetUrl}${realPath}"
@@ -52,13 +51,12 @@ class AssetMethodTagLib {
             if(configUrl){
                 return configUrl
             }
-        } 
+        }
         if(absolute && !configUrl){
             return [grailsLinkGenerator.serverBaseURL, "$mapping/"].join('/')
         }
         def contextPath = StringUtils.trimToEmpty(grailsLinkGenerator?.contextPath)
         String relativePathToResource = (contextPath + "${contextPath?.endsWith('/') ? '' : '/'}$mapping/" )
         return configUrl ?: relativePathToResource
-
     }
 }


### PR DESCRIPTION
`grails.assets.enableDigest == false` prevents insertion of cache digest into file name.

This branch is branched from `PassGrailsConfigSettingsToCore`, so it includes the single commit from pull request #273.

The pull request should remove the need for cache digests in asset file names, and, consequently, for cache digests in URLs pointing to asset files.

Is there anything else that must be done?