### PR TITLE
Simplify manifest reads

### DIFF
--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -9,20 +9,21 @@ class AssetPipelineBootStrap {
 
 
 	def init = {final servletContext ->
-		final String storagePath = grailsApplication.config.grails.assets.storagePath
-		if (!storagePath) {
+		final def storagePath = grailsApplication.config.grails.assets.storagePath
+		if (! storagePath) {
 			return
 		}
 
 		final Properties manifest = AssetPipelineConfigHolder.manifest
 
 		if (manifest) {
-			new File(storagePath).mkdirs()
+			final File storageDir = new File((String) storagePath)
+			storageDir.mkdirs()
 
 			final ApplicationContext parentContext = grailsApplication.parentContext
 
 			manifest.stringPropertyNames().each {final String propertyName ->
-				final File outputFile = new File(storagePath, propertyName)
+				final File outputFile = new File(storageDir, propertyName)
 
 				new File(outputFile.parent).mkdirs()
 
@@ -34,18 +35,18 @@ class AssetPipelineBootStrap {
 
 				outputFile.bytes = fileBytes
 
-				new File(storagePath, propertyValue).bytes = fileBytes
+				new File(storageDir, propertyValue).bytes = fileBytes
 
 				final Resource gzRes = parentContext.getResource("${assetPath}.gz")
 				if (gzRes.exists()) {
 					final byte[] gzBytes = gzRes.inputStream.bytes
 
-					new File(storagePath, "${propertyName}.gz" ).bytes = gzBytes
-					new File(storagePath, "${propertyValue}.gz").bytes = gzBytes
+					new File(storageDir, "${propertyName}.gz" ).bytes = gzBytes
+					new File(storageDir, "${propertyValue}.gz").bytes = gzBytes
 				}
 			}
 
-			manifest.store(new File(storagePath, 'manifest.properties').newWriter(), '')
+			manifest.store(new File(storageDir, 'manifest.properties').newWriter(), '')
 		}
 	}
 }

--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -6,17 +6,17 @@ class AssetPipelineBootStrap {
 	def grailsApplication
 
 
-	def init = { servletContext ->
+	def init = {servletContext ->
 		def storagePath = grailsApplication.config.grails.assets.storagePath
 		if (!storagePath) {
 			return
 		}
 		def manifest = AssetPipelineConfigHolder.manifest
 
-		if(manifest) {
+		if (manifest) {
 			def storageFile = new File(storagePath)
 			storageFile.mkdirs()
-			manifest.stringPropertyNames().each { propertyName ->
+			manifest.stringPropertyNames().each {propertyName ->
 				def propertyValue = manifest.getProperty(propertyName)
 				def res = grailsApplication.getParentContext().getResource("assets/${propertyValue}")
 
@@ -29,7 +29,7 @@ class AssetPipelineBootStrap {
 				def outputDigestFile = new File(storagePath, propertyValue)
 				outputDigestFile.bytes = fileBytes
 				def gzRes = grailsApplication.getParentContext().getResource("assets/${propertyValue}.gz")
-				if(gzRes.exists()) {
+				if (gzRes.exists()) {
 					def gzBytes = gzRes.inputStream.bytes
 					def outputGzFile = new File(storagePath, "${propertyName}.gz")
 					outputGzFile.bytes = gzBytes

--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -38,7 +38,7 @@ class AssetPipelineBootStrap {
 				}
 			}
 			def manifestFile = new File(storagePath,'manifest.properties')
-			manifest.store(manifestFile.newWriter(),"")
+			manifest.store(manifestFile.newWriter(),'')
 		}
 	}
 }

--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -1,42 +1,44 @@
-import org.apache.commons.io.FileUtils
 import asset.pipeline.AssetPipelineConfigHolder
+
+
 class AssetPipelineBootStrap {
 
-    def grailsApplication
+	def grailsApplication
 
-    def init = { servletContext ->
-        def storagePath = grailsApplication.config.grails.assets.storagePath
-        if (!storagePath) {
-            return
-        }
-        def manifest = AssetPipelineConfigHolder.manifest
 
-        if(manifest) {
-            def storageFile = new File(storagePath)
-            storageFile.mkdirs()
-            manifest.stringPropertyNames().each { propertyName ->
-                def propertyValue = manifest.getProperty(propertyName)
-                def res = grailsApplication.getParentContext().getResource("assets/${propertyValue}")
-                
-                def fileBytes = res.inputStream.bytes
+	def init = { servletContext ->
+		def storagePath = grailsApplication.config.grails.assets.storagePath
+		if (!storagePath) {
+			return
+		}
+		def manifest = AssetPipelineConfigHolder.manifest
 
-                def outputFile = new File(storagePath, propertyName)
-                def parentFile = new File(outputFile.parent)
-                parentFile.mkdirs()
-                outputFile.bytes = fileBytes
-                def outputDigestFile = new File(storagePath, propertyValue)
-                outputDigestFile.bytes = fileBytes
-                def gzRes = grailsApplication.getParentContext().getResource("assets/${propertyValue}.gz")
-                if(gzRes.exists()) {
-                    def gzBytes = gzRes.inputStream.bytes
-                    def outputGzFile = new File(storagePath, "${propertyName}.gz")
-                    outputGzFile.bytes = gzBytes
-                    def outputGzDigestFile = new File(storagePath, "${propertyValue}.gz")
-                    outputGzDigestFile.bytes = gzBytes    
-                }
-            }
-            def manifestFile = new File(storagePath,'manifest.properties')
-            manifest.store(manifestFile.newWriter(),"")
-        }
-    }
+		if(manifest) {
+			def storageFile = new File(storagePath)
+			storageFile.mkdirs()
+			manifest.stringPropertyNames().each { propertyName ->
+				def propertyValue = manifest.getProperty(propertyName)
+				def res = grailsApplication.getParentContext().getResource("assets/${propertyValue}")
+
+				def fileBytes = res.inputStream.bytes
+
+				def outputFile = new File(storagePath, propertyName)
+				def parentFile = new File(outputFile.parent)
+				parentFile.mkdirs()
+				outputFile.bytes = fileBytes
+				def outputDigestFile = new File(storagePath, propertyValue)
+				outputDigestFile.bytes = fileBytes
+				def gzRes = grailsApplication.getParentContext().getResource("assets/${propertyValue}.gz")
+				if(gzRes.exists()) {
+					def gzBytes = gzRes.inputStream.bytes
+					def outputGzFile = new File(storagePath, "${propertyName}.gz")
+					outputGzFile.bytes = gzBytes
+					def outputGzDigestFile = new File(storagePath, "${propertyValue}.gz")
+					outputGzDigestFile.bytes = gzBytes
+				}
+			}
+			def manifestFile = new File(storagePath,'manifest.properties')
+			manifest.store(manifestFile.newWriter(),"")
+		}
+	}
 }

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -42,11 +42,9 @@ class AssetProcessorService {
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		path && conf.precompiled \
-			? conf.manifest.getProperty(path)
-			: path && fileForFullName(path) != null \
-				? path
-				: null
+		isAssetPath(path, conf) \
+			? path
+			: null
 	}
 
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -33,6 +33,13 @@ class AssetProcessorService {
 	}
 
 
+	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+		path && conf.precompiled \
+			? conf.manifest.getProperty(path) ?: path
+			: path
+	}
+
+
 	String asset(Map attrs, DefaultLinkGenerator linkGenerator) {
 		def absolutePath = linkGenerator.handleAbsolute(attrs)
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -40,6 +40,13 @@ class AssetProcessorService {
 	}
 
 
+	boolean isAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+		conf.precompiled \
+			? conf.manifest.getProperty(path)
+			: AssetHelper.fileForFullName(path) != null
+	}
+
+
 	String asset(Map attrs, DefaultLinkGenerator linkGenerator) {
 		def absolutePath = linkGenerator.handleAbsolute(attrs)
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,8 +1,9 @@
 package asset.pipeline.grails
 
 
-import asset.pipeline.AssetHelper
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
+
+import static asset.pipeline.AssetHelper.fileForFullName
 
 
 class AssetProcessorService {
@@ -43,7 +44,7 @@ class AssetProcessorService {
 	boolean isAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		conf.precompiled \
 			? conf.manifest.getProperty(path)
-			: AssetHelper.fileForFullName(path) != null
+			: fileForFullName(path) != null
 	}
 
 
@@ -63,7 +64,7 @@ class AssetProcessorService {
 				}
 			}
 			else {
-				def assetFile = AssetHelper.fileForFullName(url)
+				def assetFile = fileForFullName(url)
 				if (assetFile != null) {
 					url = assetUriRootPath() + url
 					assetFound = true

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -17,10 +17,10 @@ class AssetProcessorService {
 	 * @throws IllegalArgumentException if the path contains <code>/</code>
 	 */
 	String getAssetMapping() {
-		def path = grailsApplication.config?.grails?.assets?.mapping ?: "assets"
-		if (path.contains("/")) {
+		def path = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
+		if (path.contains('/')) {
 			throw new IllegalArgumentException(
-				"The property [grails.assets.mapping] can only be one level deep.  " +
+				'The property [grails.assets.mapping] can only be one level deep.  ' +
 				"For example, 'foo' and 'bar' would be acceptable values, but 'foo/bar' is not"
 			)
 		}

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -53,32 +53,23 @@ class AssetProcessorService {
 
 		final ConfigObject conf = grailsApplication.config.grails.assets
 
-		boolean assetFound = false
+		def url = attrs.file ?: attrs.src
 
-		def url  = attrs.file ?: attrs.src
+		url \
+			? conf.precompiled \
+				? conf.manifest.getProperty(url)
+				: fileForFullName(url) != null \
+					? url
+					: null
+			: null
 
-		if (url) {
-			if (conf.precompiled) {
-				def realPath = conf.manifest.getProperty(url)
-				if (realPath) {
-					url = assetUriRootPath() + realPath
-					assetFound = true
-				}
-			}
-			else {
-				def assetFile = fileForFullName(url)
-				if (assetFile != null) {
-					url = assetUriRootPath() + url
-					assetFound = true
-				}
-			}
-		}
-
-		if (!assetFound) {
+		if (!url) {
 			return null
 		}
 
-		if (!url?.startsWith('http')) {
+		url = assetUriRootPath() + url
+
+		if (!url.startsWith('http')) {
 			if (absolutePath == null) {
 				final contextPathAttribute = attrs.contextPath?.toString()
 				final cp = contextPathAttribute == null ? linkGenerator.contextPath : contextPathAttribute

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,26 +1,29 @@
 package asset.pipeline.grails
 
+
 class AssetProcessorService {
-    static transactional = false
-    def grailsApplication
 
-    /**
-     * Retrieves the asset path from the property [grails.assets.mapping] which is used by the url mapping and the
-     * taglib.  The property cannot contain <code>/</code>, and must be one level deep
-     *
-     * @return the path
-     * @throws IllegalArgumentException if the path contains <code>/</code>
-     */
-    String getAssetMapping() {
-        def path = grailsApplication.config?.grails?.assets?.mapping ?: "assets"
-        if (path.contains("/")) {
-            String message = "the property [grails.assets.mapping] can only be one level" +
-                    "deep.  For example, 'foo' and 'bar' would be acceptable values, but 'foo/bar' is not"
-            throw new IllegalArgumentException(message)
-        }
-
-        return path
-    }
+	static transactional = false
 
 
+	def grailsApplication
+
+
+	/**
+	 * Retrieves the asset path from the property [grails.assets.mapping] which is used by the url mapping and the
+	 * taglib.  The property cannot contain <code>/</code>, and must be one level deep
+	 *
+	 * @return the path
+	 * @throws IllegalArgumentException if the path contains <code>/</code>
+	 */
+	String getAssetMapping() {
+		def path = grailsApplication.config?.grails?.assets?.mapping ?: "assets"
+		if (path.contains("/")) {
+			String message = "the property [grails.assets.mapping] can only be one level" +
+					"deep.  For example, 'foo' and 'bar' would be acceptable values, but 'foo/bar' is not"
+			throw new IllegalArgumentException(message)
+		}
+
+		return path
+	}
 }

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -47,9 +47,11 @@ class AssetProcessorService {
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		isAssetPath(path, conf) \
-			? path
-			: null
+		shouldUseManifestPath(path, conf) \
+			? conf.manifest.getProperty(path)
+			: fileForFullName(path) != null \
+				? path
+				: null
 	}
 
 
@@ -80,7 +82,7 @@ class AssetProcessorService {
 						? linkGenerator.contextPath
 						: contextPathAttribute
 
-				absolutePath = \
+				absolutePath =
 					contextPath == null \
 						? linkGenerator.handleAbsolute(absolute: true) ?: ''
 						: contextPath

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -48,12 +48,14 @@ class AssetProcessorService {
 	}
 
 
-	String asset(Map attrs, DefaultLinkGenerator linkGenerator) {
-		def absolutePath = linkGenerator.handleAbsolute(attrs)
+	String asset(final Map attrs, final DefaultLinkGenerator linkGenerator) {
+		final def absolutePath = linkGenerator.handleAbsolute(attrs)
 
-		def conf = grailsApplication.config.grails.assets
+		final ConfigObject conf = grailsApplication.config.grails.assets
+
+		boolean assetFound = false
+
 		def url  = attrs.file ?: attrs.src
-		def assetFound = false
 
 		if (url) {
 			if (conf.precompiled) {
@@ -75,22 +77,19 @@ class AssetProcessorService {
 		if (!assetFound) {
 			return null
 		}
-		else {
-			if (!url?.startsWith('http')) {
+
+		if (!url?.startsWith('http')) {
+			if (absolutePath == null) {
 				final contextPathAttribute = attrs.contextPath?.toString()
-				if (absolutePath == null) {
-					final cp = contextPathAttribute == null ? linkGenerator.getContextPath() : contextPathAttribute
-					if (cp == null) {
-						absolutePath = linkGenerator.handleAbsolute(absolute:true)
-					}
-					else {
-						absolutePath = cp
-					}
-				}
-				url = (absolutePath?:'') + (url ?: '')
+				final cp = contextPathAttribute == null ? linkGenerator.contextPath : contextPathAttribute
+				absolutePath = \
+					cp == null \
+						? linkGenerator.handleAbsolute(absolute: true)
+						: cp
 			}
-			return url
+			url = (absolutePath ?: '') + (url ?: '')
 		}
+		return url
 	}
 
 	private String assetUriRootPath() {

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -93,14 +93,10 @@ class AssetProcessorService {
 		}
 	}
 
-	private assetUriRootPath() {
-		def conf    = grailsApplication.config.grails.assets
-		def mapping = assetMapping
-		if (conf.url instanceof Closure) {
-			return conf.url.call(null)
-		}
-		else {
-			return conf.url ?: "/$mapping/"
-		}
+	private String assetUriRootPath() {
+		final def url = grailsApplication.config.grails.assets.url
+		url instanceof Closure \
+			? url.call(null)
+			: url ?: "/$assetMapping/"
 	}
 }

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -34,8 +34,13 @@ class AssetProcessorService {
 	}
 
 
+	boolean shouldUseManifestPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+		path && conf.precompiled
+	}
+
+
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		path && conf.precompiled \
+		shouldUseManifestPath(path, conf) \
 			? conf.manifest.getProperty(path) ?: path
 			: path
 	}
@@ -49,7 +54,7 @@ class AssetProcessorService {
 
 
 	boolean isAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		path && conf.precompiled \
+		shouldUseManifestPath(path, conf) \
 			? conf.manifest.getProperty(path)
 			: path && fileForFullName(path) != null
 	}

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -61,7 +61,7 @@ class AssetProcessorService {
 
 
 	String asset(final Map attrs, final DefaultLinkGenerator linkGenerator) {
-		final def absolutePath = linkGenerator.handleAbsolute(attrs)
+		def absolutePath = linkGenerator.handleAbsolute(attrs)
 
 		String url = getResolvedAssetPath(attrs.file ?: attrs.src)
 
@@ -73,15 +73,22 @@ class AssetProcessorService {
 
 		if (!url.startsWith('http')) {
 			if (absolutePath == null) {
-				final contextPathAttribute = attrs.contextPath?.toString()
-				final cp = contextPathAttribute == null ? linkGenerator.contextPath : contextPathAttribute
+				final String contextPathAttribute = attrs.contextPath?.toString()
+
+				final String contextPath =
+					contextPathAttribute == null \
+						? linkGenerator.contextPath
+						: contextPathAttribute
+
 				absolutePath = \
-					cp == null \
-						? linkGenerator.handleAbsolute(absolute: true)
-						: cp
+					contextPath == null \
+						? linkGenerator.handleAbsolute(absolute: true) ?: ''
+						: contextPath
 			}
-			url = (absolutePath ?: '') + (url ?: '')
+
+			url = absolutePath + url
 		}
+
 		return url
 	}
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -41,6 +41,17 @@ class AssetProcessorService {
 	}
 
 
+	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+		path \
+			? conf.precompiled \
+				? conf.manifest.getProperty(path)
+				: fileForFullName(path) != null \
+					? path
+					: null
+			: null
+	}
+
+
 	boolean isAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		conf.precompiled \
 			? conf.manifest.getProperty(path)
@@ -51,17 +62,7 @@ class AssetProcessorService {
 	String asset(final Map attrs, final DefaultLinkGenerator linkGenerator) {
 		final def absolutePath = linkGenerator.handleAbsolute(attrs)
 
-		final ConfigObject conf = grailsApplication.config.grails.assets
-
-		def url = attrs.file ?: attrs.src
-
-		url \
-			? conf.precompiled \
-				? conf.manifest.getProperty(url)
-				: fileForFullName(url) != null \
-					? url
-					: null
-			: null
+		String url = getResolvedAssetPath(attrs.file ?: attrs.src)
 
 		if (!url) {
 			return null

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -81,7 +81,7 @@ class AssetProcessorService {
 	private assetUriRootPath() {
 		def conf    = grailsApplication.config.grails.assets
 		def mapping = assetMapping
-		if (conf.url && conf.url instanceof Closure) {
+		if (conf.url instanceof Closure) {
 			return conf.url.call(null)
 		}
 		else {

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -53,7 +53,7 @@ class AssetProcessorService {
 	boolean isAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		path && conf.precompiled \
 			? conf.manifest.getProperty(path)
-			: fileForFullName(path) != null
+			: path && fileForFullName(path) != null
 	}
 
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -19,9 +19,10 @@ class AssetProcessorService {
 	String getAssetMapping() {
 		def path = grailsApplication.config?.grails?.assets?.mapping ?: "assets"
 		if (path.contains("/")) {
-			String message = "the property [grails.assets.mapping] can only be one level" +
-					"deep.  For example, 'foo' and 'bar' would be acceptable values, but 'foo/bar' is not"
-			throw new IllegalArgumentException(message)
+			throw new IllegalArgumentException(
+				"The property [grails.assets.mapping] can only be one level deep.  " +
+				"For example, 'foo' and 'bar' would be acceptable values, but 'foo/bar' is not"
+			)
 		}
 
 		return path

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -42,18 +42,16 @@ class AssetProcessorService {
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		path \
-			? conf.precompiled \
-				? conf.manifest.getProperty(path)
-				: fileForFullName(path) != null \
-					? path
-					: null
-			: null
+		path && conf.precompiled \
+			? conf.manifest.getProperty(path)
+			: path && fileForFullName(path) != null \
+				? path
+				: null
 	}
 
 
 	boolean isAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		conf.precompiled \
+		path && conf.precompiled \
 			? conf.manifest.getProperty(path)
 			: fileForFullName(path) != null
 	}

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,6 +1,10 @@
 package asset.pipeline.grails
 
 
+import asset.pipeline.AssetHelper
+import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
+
+
 class AssetProcessorService {
 
 	static transactional = false
@@ -26,5 +30,62 @@ class AssetProcessorService {
 		}
 
 		return path
+	}
+
+
+	String asset(Map attrs, DefaultLinkGenerator linkGenerator) {
+		def absolutePath = linkGenerator.handleAbsolute(attrs)
+
+		def conf = grailsApplication.config.grails.assets
+		def url  = attrs.file ?: attrs.src
+		def assetFound = false
+
+		if (url) {
+			if (conf.precompiled) {
+				def realPath = conf.manifest.getProperty(url)
+				if (realPath) {
+					url = assetUriRootPath() + realPath
+					assetFound = true
+				}
+			}
+			else {
+				def assetFile = AssetHelper.fileForFullName(url)
+				if (assetFile != null) {
+					url = assetUriRootPath() + url
+					assetFound = true
+				}
+			}
+		}
+
+		if (!assetFound) {
+			return null
+		}
+		else {
+			if (!url?.startsWith('http')) {
+				final contextPathAttribute = attrs.contextPath?.toString()
+				if (absolutePath == null) {
+					final cp = contextPathAttribute == null ? linkGenerator.getContextPath() : contextPathAttribute
+					if (cp == null) {
+						absolutePath = linkGenerator.handleAbsolute(absolute:true)
+					}
+					else {
+						absolutePath = cp
+					}
+				}
+				url = (absolutePath?:'') + (url ?: '')
+			}
+			return url
+		}
+	}
+
+	private assetUriRootPath() {
+		def conf    = grailsApplication.config.grails.assets
+		def mapping = assetMapping
+		if (conf.url && conf.url instanceof Closure) {
+			return conf.url.call(null)
+		}
+		else {
+			return conf.url ?: "/$mapping/"
+		}
 	}
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -17,17 +17,11 @@ class AssetMethodTagLib {
 
 	def assetPath = { attrs ->
 		def src
-		//unused
-		def ignorePrefix = false
 		def absolute = false
 		if (attrs instanceof Map) {
-
 			src = attrs.src
-			//unused
-			ignorePrefix = attrs.containsKey('ignorePrefix')? attrs.ignorePrefix : false
 			absolute = attrs.containsKey('absolute') ? attrs.absolute : false
 		} else {
-
 			src = attrs
 		}
 
@@ -45,7 +39,6 @@ class AssetMethodTagLib {
 	}
 
 	private assetUriRootPath(grailsApplication, request, absolute=false) {
-		def context = grailsApplication.mainContext //unused
 		def conf    = grailsApplication.config.grails.assets
 		def mapping = assetProcessorService.assetMapping
 		def configUrl = conf.url

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -29,15 +29,12 @@ class AssetMethodTagLib {
 
 		final def conf = grailsApplication.config.grails.assets
 
-		final String assetUrl = assetUriRootPath(absolute)
+		final String path = \
+			src && conf.precompiled \
+				? conf.manifest.getProperty(src) ?: src
+				: src
 
-		if (conf.precompiled && src) {
-			final def realPath = conf.manifest.getProperty(src)
-			if (realPath) {
-				return "${assetUrl}${realPath}"
-			}
-		}
-		return "${assetUrl}${src}"
+		return assetUriRootPath(absolute) + path
 	}
 
 	private String assetUriRootPath(final boolean absolute) {

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -1,64 +1,65 @@
 package asset.pipeline.grails
 
-import grails.util.Environment
+
 import org.apache.commons.lang.StringUtils
+
 
 class AssetMethodTagLib {
 
-    static namespace = "g"
-    static returnObjectForTags = ['assetPath']
-
-    def grailsApplication
-    def assetProcessorService
-    def grailsLinkGenerator
-
-    def assetPath = { attrs ->
-        def src
-        //unused
-        def ignorePrefix = false
-        def absolute = false
-        if (attrs instanceof Map) {
-            
-            src = attrs.src
-            //unused
-            ignorePrefix = attrs.containsKey('ignorePrefix')? attrs.ignorePrefix : false
-            absolute = attrs.containsKey('absolute') ? attrs.absolute : false
-        } else {
-            
-            src = attrs
-        }
-       
-        def conf = grailsApplication.config.grails.assets
-
-        def assetUrl = assetUriRootPath(grailsApplication, request, absolute)
-
-        if(conf.precompiled && src) {
-            def realPath = conf.manifest.getProperty(src)
-            if(realPath) {
-                return "${assetUrl}${realPath}"
-            }
-        }
-        return "${assetUrl}${src}"
-    }
+	static namespace = "g"
+	static returnObjectForTags = ['assetPath']
 
 
-    private assetUriRootPath(grailsApplication, request, absolute=false) {
-        def context = grailsApplication.mainContext //unused
-        def conf    = grailsApplication.config.grails.assets
-        def mapping = assetProcessorService.assetMapping
-        def configUrl = conf.url
-        if(conf.url && conf.url instanceof Closure) {
-            configUrl = conf.url.call(request)
-            if(configUrl){
-                return configUrl
-            }
-        } 
-        if(absolute && !configUrl){
-            return [grailsLinkGenerator.serverBaseURL, "$mapping/"].join('/')
-        }
-        def contextPath = StringUtils.trimToEmpty(grailsLinkGenerator?.contextPath)
-        String relativePathToResource = (contextPath + "${contextPath?.endsWith('/') ? '' : '/'}$mapping/" )
-        return configUrl ?: relativePathToResource
+	def grailsApplication
+	def assetProcessorService
+	def grailsLinkGenerator
 
-    }
+
+	def assetPath = { attrs ->
+		def src
+		//unused
+		def ignorePrefix = false
+		def absolute = false
+		if (attrs instanceof Map) {
+
+			src = attrs.src
+			//unused
+			ignorePrefix = attrs.containsKey('ignorePrefix')? attrs.ignorePrefix : false
+			absolute = attrs.containsKey('absolute') ? attrs.absolute : false
+		} else {
+
+			src = attrs
+		}
+
+		def conf = grailsApplication.config.grails.assets
+
+		def assetUrl = assetUriRootPath(grailsApplication, request, absolute)
+
+		if(conf.precompiled && src) {
+			def realPath = conf.manifest.getProperty(src)
+			if(realPath) {
+				return "${assetUrl}${realPath}"
+			}
+		}
+		return "${assetUrl}${src}"
+	}
+
+	private assetUriRootPath(grailsApplication, request, absolute=false) {
+		def context = grailsApplication.mainContext //unused
+		def conf    = grailsApplication.config.grails.assets
+		def mapping = assetProcessorService.assetMapping
+		def configUrl = conf.url
+		if(conf.url && conf.url instanceof Closure) {
+			configUrl = conf.url.call(request)
+			if(configUrl){
+				return configUrl
+			}
+		}
+		if(absolute && !configUrl){
+			return [grailsLinkGenerator.serverBaseURL, "$mapping/"].join('/')
+		}
+		def contextPath = StringUtils.trimToEmpty(grailsLinkGenerator?.contextPath)
+		String relativePathToResource = (contextPath + "${contextPath?.endsWith('/') ? '' : '/'}$mapping/" )
+		return configUrl ?: relativePathToResource
+	}
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -43,7 +43,7 @@ class AssetMethodTagLib {
 		def conf    = grailsApplication.config.grails.assets
 		def mapping = assetProcessorService.assetMapping
 		def configUrl = conf.url
-		if (conf.url && conf.url instanceof Closure) {
+		if (conf.url instanceof Closure) {
 			configUrl = conf.url.call(request)
 			if (configUrl) {
 				return configUrl

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -15,7 +15,7 @@ class AssetMethodTagLib {
 	def grailsLinkGenerator
 
 
-	def assetPath = {final Map<String, ?> attrs ->
+	def assetPath = {final def attrs ->
 		final def src
 		final boolean absolute
 		if (attrs instanceof Map) {

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -15,13 +15,14 @@ class AssetMethodTagLib {
 	def grailsLinkGenerator
 
 
-	def assetPath = { attrs ->
+	def assetPath = {attrs ->
 		def src
 		def absolute = false
 		if (attrs instanceof Map) {
 			src = attrs.src
 			absolute = attrs.containsKey('absolute') ? attrs.absolute : false
-		} else {
+		}
+		else {
 			src = attrs
 		}
 
@@ -29,9 +30,9 @@ class AssetMethodTagLib {
 
 		def assetUrl = assetUriRootPath(grailsApplication, request, absolute)
 
-		if(conf.precompiled && src) {
+		if (conf.precompiled && src) {
 			def realPath = conf.manifest.getProperty(src)
-			if(realPath) {
+			if (realPath) {
 				return "${assetUrl}${realPath}"
 			}
 		}
@@ -42,17 +43,17 @@ class AssetMethodTagLib {
 		def conf    = grailsApplication.config.grails.assets
 		def mapping = assetProcessorService.assetMapping
 		def configUrl = conf.url
-		if(conf.url && conf.url instanceof Closure) {
+		if (conf.url && conf.url instanceof Closure) {
 			configUrl = conf.url.call(request)
-			if(configUrl){
+			if (configUrl) {
 				return configUrl
 			}
 		}
-		if(absolute && !configUrl){
+		if (absolute && !configUrl) {
 			return [grailsLinkGenerator.serverBaseURL, "$mapping/"].join('/')
 		}
 		def contextPath = StringUtils.trimToEmpty(grailsLinkGenerator?.contextPath)
-		String relativePathToResource = (contextPath + "${contextPath?.endsWith('/') ? '' : '/'}$mapping/" )
+		String relativePathToResource = (contextPath + "${contextPath?.endsWith('/') ? '' : '/'}$mapping/")
 		return configUrl ?: relativePathToResource
 	}
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -27,14 +27,7 @@ class AssetMethodTagLib {
 			absolute = false
 		}
 
-		final def conf = grailsApplication.config.grails.assets
-
-		final String path = \
-			src && conf.precompiled \
-				? conf.manifest.getProperty(src) ?: src
-				: src
-
-		return assetUriRootPath(absolute) + path
+		return assetUriRootPath(absolute) + assetProcessorService.getAssetPath(src)
 	}
 
 	private String assetUriRootPath(final boolean absolute) {

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -10,8 +10,8 @@ class AssetMethodTagLib {
 	static returnObjectForTags = ['assetPath']
 
 
-	def grailsApplication
 	def assetProcessorService
+	def grailsApplication
 	def grailsLinkGenerator
 
 

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -6,7 +6,7 @@ import org.apache.commons.lang.StringUtils
 
 class AssetMethodTagLib {
 
-	static namespace = "g"
+	static namespace = 'g'
 	static returnObjectForTags = ['assetPath']
 
 

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -140,12 +140,12 @@ class AssetsTagLib {
 	}
 
 	def assetPathExists = {attrs, body ->
-		out <<
-			(
-				isAssetPath(attrs.remove('src')) \
-					? (body() ?: true)
-					: ''
-			)
+		if (isAssetPath(attrs.remove('src'))) {
+			out << (body() ?: true)
+		}
+		else {
+			out << ''
+		}
 	}
 
 	boolean isAssetPath(src) {

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -1,15 +1,20 @@
 package asset.pipeline.grails
 
-import grails.util.Environment
-import asset.pipeline.AssetPipeline
+
 import asset.pipeline.AssetHelper
+import asset.pipeline.AssetPipeline
+
 
 class AssetsTagLib {
 
 	static namespace = "asset"
 	static returnObjectForTags = ['assetPath']
+
 	private static final LINE_BREAK = System.getProperty('line.separator') ?: '\n'
+
+
 	def grailsApplication
+
 
 	/**
 	 * @attr src REQUIRED
@@ -22,7 +27,7 @@ class AssetsTagLib {
 		def extension
 
 		def conf = grailsApplication.config.grails.assets
-		
+
 		def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrs.bundle != true)
 
 		if(!nonBundledMode) {
@@ -89,7 +94,7 @@ class AssetsTagLib {
 
 	def image = { attrs ->
 		def src = attrs.remove('src')
-        def absolute = attrs.remove('absolute')
+		def absolute = attrs.remove('absolute')
 		out << "<img src=\"${assetPath(src:src, absolute: absolute)}\" ${paramsToHtmlAttr(attrs)}/>"
 	}
 
@@ -132,12 +137,12 @@ class AssetsTagLib {
 	def assetPathExists = { attrs, body ->
 		def src = attrs.remove('src')
 		def exists = isAssetPath(src)
-            if (exists){
-                out << (body() ?: true)
-            } else {
-                out << ''
-            }
-    }
+			if (exists){
+				out << (body() ?: true)
+			} else {
+				out << ''
+			}
+	}
 
 	def isAssetPath(src) {
 		def conf = grailsApplication.config.grails.assets
@@ -158,5 +163,4 @@ class AssetsTagLib {
 	private paramsToHtmlAttr(attrs) {
 		attrs.collect { key, value -> "${key}=\"${value.toString().replace('"', '\\"')}\"" }?.join(" ")
 	}
-
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -13,6 +13,7 @@ class AssetsTagLib {
 	private static final LINE_BREAK = System.getProperty('line.separator') ?: '\n'
 
 
+	def assetProcessorService
 	def grailsApplication
 
 
@@ -148,10 +149,7 @@ class AssetsTagLib {
 	}
 
 	boolean isAssetPath(src) {
-		def conf = grailsApplication.config.grails.assets
-		conf.precompiled \
-			? conf.manifest.getProperty(src)
-			: AssetHelper.fileForFullName(src) != null
+		assetProcessorService.isAssetPath(src)
 	}
 
 	private paramsToHtmlAttr(attrs) {

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -7,7 +7,7 @@ import asset.pipeline.AssetPipeline
 
 class AssetsTagLib {
 
-	static namespace = "asset"
+	static namespace = 'asset'
 	static returnObjectForTags = ['assetPath']
 
 	private static final LINE_BREAK = System.getProperty('line.separator') ?: '\n'
@@ -33,22 +33,22 @@ class AssetsTagLib {
 		if(!nonBundledMode) {
 			out << "<script src=\"${assetPath(src:src)}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>"
 		} else {
-			if (src.lastIndexOf(".") >= 0) {
-				uri = src.substring(0, src.lastIndexOf("."))
-				extension = src.substring(src.lastIndexOf(".") + 1)
+			if (src.lastIndexOf('.') >= 0) {
+				uri = src.substring(0, src.lastIndexOf('.'))
+				extension = src.substring(src.lastIndexOf('.') + 1)
 			} else {
 				uri = src
 				extension = 'js'
 			}
 			// def startTime = new Date().time
 			def list = AssetPipeline.getDependencyList(uri, 'application/javascript', extension)
-			def modifierParams = ["compile=false"]
+			def modifierParams = ['compile=false']
 			if(attrs.charset) {
 				modifierParams << "encoding=${attrs.charset}"
 			}
 			list.each { dep ->
 				def depAssetPath = assetPath([src: "${dep.path}", ignorePrefix:true])
-				out << "<script src=\"${depAssetPath}?${modifierParams.join("&")}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>${LINE_BREAK}"
+				out << "<script src=\"${depAssetPath}?${modifierParams.join('&')}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>${LINE_BREAK}"
 			}
 			// println "Fetching Dev Mode Dependency List Time ${new Date().time - startTime}"
 		}
@@ -68,26 +68,26 @@ class AssetsTagLib {
 		def conf = grailsApplication.config.grails.assets
 		def uri
 		def extension
-	    def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrs.bundle != true)
+		def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrs.bundle != true)
 
 		if(!nonBundledMode) {
 			out << link([rel: 'stylesheet', href:src] + attrs)
 		} else {
-			if (src.lastIndexOf(".") >= 0) {
-				uri = src.substring(0, src.lastIndexOf("."))
-				extension = src.substring(src.lastIndexOf(".") + 1)
+			if (src.lastIndexOf('.') >= 0) {
+				uri = src.substring(0, src.lastIndexOf('.'))
+				extension = src.substring(src.lastIndexOf('.') + 1)
 			} else {
 				uri = src
 				extension = 'css'
 			}
 			def list = AssetPipeline.getDependencyList(uri, 'text/css', extension)
-			def modifierParams = ["compile=false"]
+			def modifierParams = ['compile=false']
 			if(attrs.charset) {
 				modifierParams << "encoding=${attrs.charset}"
 			}
 			list.each { dep ->
 				def depAssetPath = assetPath([src: "${dep.path}", ignorePrefix:true])
-				out << "<link rel=\"stylesheet\" href=\"${depAssetPath}?${modifierParams.join("&")}\" ${paramsToHtmlAttr(attrs)} />${LINE_BREAK}"
+				out << "<link rel=\"stylesheet\" href=\"${depAssetPath}?${modifierParams.join('&')}\" ${paramsToHtmlAttr(attrs)} />${LINE_BREAK}"
 			}
 		}
 	}
@@ -161,6 +161,6 @@ class AssetsTagLib {
 	}
 
 	private paramsToHtmlAttr(attrs) {
-		attrs.collect { key, value -> "${key}=\"${value.toString().replace('"', '\\"')}\"" }?.join(" ")
+		attrs.collect { key, value -> "${key}=\"${value.toString().replace('"', '\\"')}\"" }?.join(' ')
 	}
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -19,7 +19,7 @@ class AssetsTagLib {
 	/**
 	 * @attr src REQUIRED
 	 */
-	def javascript = { attrs ->
+	def javascript = {attrs ->
 		def src = attrs.remove('src')
 		attrs.remove('href')
 		src = "${AssetHelper.nameWithoutExtension(src)}.js"
@@ -32,21 +32,23 @@ class AssetsTagLib {
 
 		if(!nonBundledMode) {
 			out << "<script src=\"${assetPath(src:src)}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>"
-		} else {
+		}
+		else {
 			if (src.lastIndexOf('.') >= 0) {
 				uri = src.substring(0, src.lastIndexOf('.'))
 				extension = src.substring(src.lastIndexOf('.') + 1)
-			} else {
+			}
+			else {
 				uri = src
 				extension = 'js'
 			}
 			// def startTime = new Date().time
 			def list = AssetPipeline.getDependencyList(uri, 'application/javascript', extension)
 			def modifierParams = ['compile=false']
-			if(attrs.charset) {
+			if (attrs.charset) {
 				modifierParams << "encoding=${attrs.charset}"
 			}
-			list.each { dep ->
+			list.each {dep ->
 				def depAssetPath = assetPath([src: "${dep.path}", ignorePrefix:true])
 				out << "<script src=\"${depAssetPath}?${modifierParams.join('&')}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>${LINE_BREAK}"
 			}
@@ -58,10 +60,10 @@ class AssetsTagLib {
 	 * @attr href OPTIONAL alternative to src
 	 * @attr src OPTIONAL alternative to href
 	 */
-	def stylesheet = { attrs ->
+	def stylesheet = {attrs ->
 		def src  = attrs.remove('src')
 		def href = attrs.remove('href')
-		if(href) {
+		if (href) {
 			src = href
 		}
 		src = "${AssetHelper.nameWithoutExtension(src)}.css"
@@ -72,27 +74,29 @@ class AssetsTagLib {
 
 		if(!nonBundledMode) {
 			out << link([rel: 'stylesheet', href:src] + attrs)
-		} else {
+		}
+		else {
 			if (src.lastIndexOf('.') >= 0) {
 				uri = src.substring(0, src.lastIndexOf('.'))
 				extension = src.substring(src.lastIndexOf('.') + 1)
-			} else {
+			}
+			else {
 				uri = src
 				extension = 'css'
 			}
 			def list = AssetPipeline.getDependencyList(uri, 'text/css', extension)
 			def modifierParams = ['compile=false']
-			if(attrs.charset) {
+			if (attrs.charset) {
 				modifierParams << "encoding=${attrs.charset}"
 			}
-			list.each { dep ->
+			list.each {dep ->
 				def depAssetPath = assetPath([src: "${dep.path}", ignorePrefix:true])
 				out << "<link rel=\"stylesheet\" href=\"${depAssetPath}?${modifierParams.join('&')}\" ${paramsToHtmlAttr(attrs)} />${LINE_BREAK}"
 			}
 		}
 	}
 
-	def image = { attrs ->
+	def image = {attrs ->
 		def src = attrs.remove('src')
 		def absolute = attrs.remove('absolute')
 		out << "<img src=\"${assetPath(src:src, absolute: absolute)}\" ${paramsToHtmlAttr(attrs)}/>"
@@ -104,56 +108,58 @@ class AssetsTagLib {
 	 * @attr rel REQUIRED
 	 * @attr type OPTIONAL
 	 */
-	def link = { attrs ->
+	def link = {attrs ->
 		def href = attrs.remove('href')
 		out << "<link ${paramsToHtmlAttr(attrs)} href=\"${assetPath(src:href)}\"/>"
 	}
 
 
-	def script = { attrs, body ->
+	def script = {attrs, body ->
 		def assetBlocks = request.getAttribute('assetScriptBlocks')
-		if(!assetBlocks) {
+		if (!assetBlocks) {
 			assetBlocks = []
 		}
 		assetBlocks << [attrs: attrs, body: body()]
 		request.setAttribute('assetScriptBlocks', assetBlocks)
 	}
 
-	def deferredScripts = { attrs ->
+	def deferredScripts = {attrs ->
 		def assetBlocks = request.getAttribute('assetScriptBlocks')
-		if(!assetBlocks) {
+		if (!assetBlocks) {
 			return
 		}
-		assetBlocks.each { assetBlock ->
+		assetBlocks.each {assetBlock ->
 			out << "<script ${paramsToHtmlAttr(assetBlock.attrs)}>${assetBlock.body}</script>"
 		}
 	}
 
 
-	def assetPath = { attrs ->
+	def assetPath = {attrs ->
 		g.assetPath(attrs)
 	}
 
-	def assetPathExists = { attrs, body ->
+	def assetPathExists = {attrs, body ->
 		def src = attrs.remove('src')
 		def exists = isAssetPath(src)
-			if (exists){
+			if (exists) {
 				out << (body() ?: true)
-			} else {
+			}
+			else {
 				out << ''
 			}
 	}
 
 	def isAssetPath(src) {
 		def conf = grailsApplication.config.grails.assets
-		if(conf.precompiled) {
+		if (conf.precompiled) {
 			def realPath = conf.manifest.getProperty(src)
-			if(realPath) {
+			if (realPath) {
 				return true
 			}
-		} else {
+		}
+		else {
 			def assetFile = AssetHelper.fileForFullName(src)
-			if(assetFile != null) {
+			if (assetFile != null) {
 				return true
 			}
 		}
@@ -161,6 +167,6 @@ class AssetsTagLib {
 	}
 
 	private paramsToHtmlAttr(attrs) {
-		attrs.collect { key, value -> "${key}=\"${value.toString().replace('"', '\\"')}\"" }?.join(' ')
+		attrs.collect {key, value -> "${key}=\"${value.toString().replace('"', '\\"')}\""}?.join(' ')
 	}
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -147,21 +147,11 @@ class AssetsTagLib {
 			)
 	}
 
-	def isAssetPath(src) {
+	boolean isAssetPath(src) {
 		def conf = grailsApplication.config.grails.assets
-		if (conf.precompiled) {
-			def realPath = conf.manifest.getProperty(src)
-			if (realPath) {
-				return true
-			}
-		}
-		else {
-			def assetFile = AssetHelper.fileForFullName(src)
-			if (assetFile != null) {
-				return true
-			}
-		}
-		return false
+		conf.precompiled \
+			? conf.manifest.getProperty(src)
+			: AssetHelper.fileForFullName(src) != null
 	}
 
 	private paramsToHtmlAttr(attrs) {

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -91,7 +91,7 @@ class AssetsTagLib {
 			}
 			list.each {dep ->
 				def depAssetPath = assetPath([src: "${dep.path}", ignorePrefix:true])
-				out << "<link rel=\"stylesheet\" href=\"${depAssetPath}?${modifierParams.join('&')}\" ${paramsToHtmlAttr(attrs)} />${LINE_BREAK}"
+				out << "<link rel=\"stylesheet\" href=\"${depAssetPath}?${modifierParams.join('&')}\" ${paramsToHtmlAttr(attrs)}/>${LINE_BREAK}"
 			}
 		}
 	}
@@ -139,14 +139,12 @@ class AssetsTagLib {
 	}
 
 	def assetPathExists = {attrs, body ->
-		def src = attrs.remove('src')
-		def exists = isAssetPath(src)
-			if (exists) {
-				out << (body() ?: true)
-			}
-			else {
-				out << ''
-			}
+		out <<
+			(
+				isAssetPath(attrs.remove('src')) \
+					? (body() ?: true)
+					: ''
+			)
 	}
 
 	def isAssetPath(src) {

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -1,6 +1,6 @@
-import org.apache.tools.ant.DirectoryScanner
 import org.codehaus.groovy.grails.plugins.GrailsPluginUtils
-// import asset.pipeline.*
+
+
 includeTargets << grailsScript("_PackagePlugins")
 includeTargets << grailsScript("_GrailsBootstrap")
 
@@ -8,45 +8,43 @@ target(assetClean: "Cleans Compiled Assets Directory") {
 	// Clear compiled assets folder
 	println "Asset Precompiler Args ${argsMap}"
 	def assetDir = new File(argsMap.target ?: "target/assets")
-	if(assetDir.exists()) {
+	if (assetDir.exists()) {
 		assetDir.deleteDir()
 	}
 }
 
 target(assetCompile: "Precompiles assets in the application as specified by the precompile glob!") {
 	depends(configureProxy,compile)
-	def assetPipelineConfigHolder   = classLoader.loadClass('asset.pipeline.AssetPipelineConfigHolder')
-	def defaultResourceLoader       = classLoader.loadClass('org.springframework.core.io.DefaultResourceLoader').newInstance(classLoader)
-	def fileSystemAssetResolver     = classLoader.loadClass('asset.pipeline.fs.FileSystemAssetResolver')
-	def jarAssetResolver            = classLoader.loadClass('asset.pipeline.fs.JarAssetResolver')
-	def assetHelper                 = classLoader.loadClass('asset.pipeline.AssetHelper')
-	def assetCompilerClass          = classLoader.loadClass('asset.pipeline.AssetCompiler')
-	def directiveProcessorClass     = classLoader.loadClass('asset.pipeline.DirectiveProcessor')
+	def assetPipelineConfigHolder = classLoader.loadClass('asset.pipeline.AssetPipelineConfigHolder')
+	def defaultResourceLoader     = classLoader.loadClass('org.springframework.core.io.DefaultResourceLoader').newInstance(classLoader)
+	def fileSystemAssetResolver   = classLoader.loadClass('asset.pipeline.fs.FileSystemAssetResolver')
+	def jarAssetResolver          = classLoader.loadClass('asset.pipeline.fs.JarAssetResolver')
+	def assetHelper               = classLoader.loadClass('asset.pipeline.AssetHelper')
+	def assetCompilerClass        = classLoader.loadClass('asset.pipeline.AssetCompiler')
+	def directiveProcessorClass   = classLoader.loadClass('asset.pipeline.DirectiveProcessor')
 
 	def assetConfig                = [specs:[]] //Additional Asset Specs (Asset File formats) that we want to process.
 
 	event("AssetPrecompileStart", [assetConfig])
-	assetConfig.minifyJs = config.grails.assets.containsKey('minifyJs') ? config.grails.assets.minifyJs : (argsMap.containsKey('minifyJs') ? argsMap.minifyJs == 'true' : true)
-	assetConfig.minifyCss = config.grails.assets.containsKey('minifyCss') ? config.grails.assets.minifyCss : (argsMap.containsKey('minifyCss') ? argsMap.minifyCss == 'true' : true)
-	assetConfig.minifyOptions = config.grails.assets.minifyOptions
-	assetConfig.compileDir = "${basedir}/target/assets"
-	assetConfig.excludesGzip = config.grails.assets.excludesGzip
+	assetConfig.minifyJs         = config.grails.assets.containsKey('minifyJs')  ? config.grails.assets.minifyJs  : (argsMap.containsKey('minifyJs')  ? argsMap.minifyJs  == 'true' : true)
+	assetConfig.minifyCss        = config.grails.assets.containsKey('minifyCss') ? config.grails.assets.minifyCss : (argsMap.containsKey('minifyCss') ? argsMap.minifyCss == 'true' : true)
+	assetConfig.minifyOptions    = config.grails.assets.minifyOptions
+	assetConfig.compileDir       = "${basedir}/target/assets"
+	assetConfig.excludesGzip     = config.grails.assets.excludesGzip
 	assetConfig.enableSourceMaps = config.grails.assets.containsKey('enableSourceMaps') ? config.grails.assets.enableSourceMaps : true
-	assetConfig.skipNonDigests = config.grails.assets.containsKey('skipNonDigests') ? config.grails.assets.skipNonDigests : true
+	assetConfig.skipNonDigests   = config.grails.assets.containsKey('skipNonDigests') ? config.grails.assets.skipNonDigests : true
 	//Add Resolvers for Grails
 	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application',"${basedir}/grails-app/assets"))
 
-	for(plugin in GrailsPluginUtils.pluginInfos) {
-		def assetPath = [plugin.pluginDir.getPath(), "grails-app", "assets"].join(File.separator)
+	for (plugin in GrailsPluginUtils.pluginInfos) {
+		def assetPath    = [plugin.pluginDir.getPath(), "grails-app", "assets"].join(File.separator)
 		def fallbackPath = [plugin.pluginDir.getPath(), "web-app"].join(File.separator)
 		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name,assetPath))
 		assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance(plugin.name,fallbackPath,true))
 	}
 
-
 	grailsSettings.runtimeDependencies.each { dep ->
-
-		if(dep.name.endsWith('.jar')) {
+		if (dep.name.endsWith('.jar')) {
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/assets'))
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/static'))
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/resources'))
@@ -54,11 +52,11 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 	}
 
 	grailsSettings.providedDependencies.each { dep ->
-		if(dep.name.endsWith('.jar')) {
+		if (dep.name.endsWith('.jar')) {
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/assets'))
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/static'))
 			assetPipelineConfigHolder.registerResolver(jarAssetResolver.newInstance(dep.name,dep.path,'META-INF/resources'))
-		}	
+		}
 	}
 
 	assetPipelineConfigHolder.config = config.grails.assets
@@ -72,15 +70,13 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 
 	// Initialize Exclude/Include Rules
 	config.grails.assets.plugin.each { pluginName, value ->
-
-		if(value.excludes) {
+		if (value.excludes) {
 			assetCompiler.excludeRules[pluginName] = value.excludes
 		}
-		if(value.includes) {
+		if (value.includes) {
 			assetCompiler.includeRules[pluginName] = value.includes
 		}
 	}
 	assetCompiler.compile()
 	event("AssetPrecompileComplete", [assetConfig])
-
 }

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -15,6 +15,7 @@ target(assetClean: "Cleans Compiled Assets Directory") {
 
 target(assetCompile: "Precompiles assets in the application as specified by the precompile glob!") {
 	depends(configureProxy,compile)
+
 	def assetPipelineConfigHolder = classLoader.loadClass('asset.pipeline.AssetPipelineConfigHolder')
 	def defaultResourceLoader     = classLoader.loadClass('org.springframework.core.io.DefaultResourceLoader').newInstance(classLoader)
 	def fileSystemAssetResolver   = classLoader.loadClass('asset.pipeline.fs.FileSystemAssetResolver')
@@ -23,16 +24,18 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 	def assetCompilerClass        = classLoader.loadClass('asset.pipeline.AssetCompiler')
 	def directiveProcessorClass   = classLoader.loadClass('asset.pipeline.DirectiveProcessor')
 
-	def assetConfig                = [specs:[]] //Additional Asset Specs (Asset File formats) that we want to process.
+	def assetConfig               = [specs:[]] //Additional Asset Specs (Asset File formats) that we want to process.
 
 	event("AssetPrecompileStart", [assetConfig])
+
 	assetConfig.minifyJs         = config.grails.assets.containsKey('minifyJs')  ? config.grails.assets.minifyJs  : (argsMap.containsKey('minifyJs')  ? argsMap.minifyJs  == 'true' : true)
 	assetConfig.minifyCss        = config.grails.assets.containsKey('minifyCss') ? config.grails.assets.minifyCss : (argsMap.containsKey('minifyCss') ? argsMap.minifyCss == 'true' : true)
 	assetConfig.minifyOptions    = config.grails.assets.minifyOptions
 	assetConfig.compileDir       = "${basedir}/target/assets"
 	assetConfig.excludesGzip     = config.grails.assets.excludesGzip
 	assetConfig.enableSourceMaps = config.grails.assets.containsKey('enableSourceMaps') ? config.grails.assets.enableSourceMaps : true
-	assetConfig.skipNonDigests   = config.grails.assets.containsKey('skipNonDigests') ? config.grails.assets.skipNonDigests : true
+	assetConfig.skipNonDigests   = config.grails.assets.containsKey('skipNonDigests')   ? config.grails.assets.skipNonDigests   : true
+
 	//Add Resolvers for Grails
 	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application',"${basedir}/grails-app/assets"))
 

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -34,32 +34,35 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 		def url  = attrs.file ?: attrs.src
 		def assetFound = false
 
-		if(url) {
-			if(conf.precompiled) {
+		if (url) {
+			if (conf.precompiled) {
 				def realPath = conf.manifest.getProperty(url)
-				if(realPath) {
+				if (realPath) {
 					url = assetUriRootPath() + realPath
 					assetFound = true
 				}
-			} else {
+			}
+			else {
 				def assetFile = AssetHelper.fileForFullName(url)
-				if(assetFile != null) {
+				if (assetFile != null) {
 					url = assetUriRootPath() + url
 					assetFound = true
 				}
 			}
 		}
 
-		if(!assetFound) {
+		if (!assetFound) {
 			return null
-		} else {
-			if(!url?.startsWith('http')) {
+		}
+		else {
+			if (!url?.startsWith('http')) {
 				final contextPathAttribute = attrs.contextPath?.toString()
-				if(absolutePath == null) {
+				if (absolutePath == null) {
 					final cp = contextPathAttribute == null ? getContextPath() : contextPathAttribute
-					if(cp == null) {
+					if (cp == null) {
 						absolutePath = handleAbsolute(absolute:true)
-					} else {
+					}
+					else {
 						absolutePath = cp
 					}
 				}
@@ -72,9 +75,10 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	private assetUriRootPath() {
 		def conf    = grailsApplication.config.grails.assets
 		def mapping = assetProcessorService.assetMapping
-		if(conf.url && conf.url instanceof Closure) {
+		if (conf.url && conf.url instanceof Closure) {
 			return conf.url.call(null)
-		} else {
+		}
+		else {
 			return conf.url ?: "/$mapping/"
 		}
 	}

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -1,7 +1,6 @@
 package asset.pipeline.grails
 
 
-import asset.pipeline.AssetHelper
 import groovy.util.logging.Slf4j
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
@@ -24,62 +23,10 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	}
 
 	/**
-	* Finds an Asset from the asset-pipeline based on the file attribute.
-	* @param attrs [file]
-	*/
+	 * Finds an Asset from the asset-pipeline based on the file attribute.
+	 * @param attrs [file]
+	 */
 	String asset(Map attrs) {
-		def absolutePath = handleAbsolute(attrs)
-
-		def conf = grailsApplication.config.grails.assets
-		def url  = attrs.file ?: attrs.src
-		def assetFound = false
-
-		if (url) {
-			if (conf.precompiled) {
-				def realPath = conf.manifest.getProperty(url)
-				if (realPath) {
-					url = assetUriRootPath() + realPath
-					assetFound = true
-				}
-			}
-			else {
-				def assetFile = AssetHelper.fileForFullName(url)
-				if (assetFile != null) {
-					url = assetUriRootPath() + url
-					assetFound = true
-				}
-			}
-		}
-
-		if (!assetFound) {
-			return null
-		}
-		else {
-			if (!url?.startsWith('http')) {
-				final contextPathAttribute = attrs.contextPath?.toString()
-				if (absolutePath == null) {
-					final cp = contextPathAttribute == null ? getContextPath() : contextPathAttribute
-					if (cp == null) {
-						absolutePath = handleAbsolute(absolute:true)
-					}
-					else {
-						absolutePath = cp
-					}
-				}
-				url = (absolutePath?:'') + (url ?: '')
-			}
-			return url
-		}
-	}
-
-	private assetUriRootPath() {
-		def conf    = grailsApplication.config.grails.assets
-		def mapping = assetProcessorService.assetMapping
-		if (conf.url && conf.url instanceof Closure) {
-			return conf.url.call(null)
-		}
-		else {
-			return conf.url ?: "/$mapping/"
-		}
+		assetProcessorService.asset(attrs, this)
 	}
 }

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -19,7 +19,7 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 
 
 	String resource(Map attrs) {
-		return asset(attrs) ?: super.resource(attrs)
+		asset(attrs) ?: super.resource(attrs)
 	}
 
 	/**

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -2,14 +2,11 @@ package asset.pipeline.grails
 
 
 import groovy.util.logging.Slf4j
-import org.codehaus.groovy.grails.commons.GrailsApplication
-import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
 
 
 @Slf4j
-class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.CachingLinkGenerator implements GrailsApplicationAware {
+class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.CachingLinkGenerator {
 
-	GrailsApplication grailsApplication
 	def assetProcessorService
 
 

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -1,19 +1,23 @@
 package asset.pipeline.grails
 
-import org.codehaus.groovy.grails.commons.GrailsApplication
-import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
 
 import asset.pipeline.AssetHelper
 import groovy.util.logging.Slf4j
+import org.codehaus.groovy.grails.commons.GrailsApplication
+import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
+
 
 @Slf4j
 class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.CachingLinkGenerator implements GrailsApplicationAware {
+
 	GrailsApplication grailsApplication
 	def assetProcessorService
+
 
 	CachingLinkGenerator(String serverUrl) {
 		super(serverUrl)
 	}
+
 
 	String resource(Map attrs) {
 		return asset(attrs) ?: super.resource(attrs)
@@ -76,5 +80,4 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 			return conf.url ?: "/$mapping/"
 		}
 	}
-
 }

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -30,7 +30,6 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	String asset(Map attrs) {
 		def absolutePath = handleAbsolute(attrs)
 
-		def absolute = attrs[CachingLinkGenerator.ATTRIBUTE_ABSOLUTE]
 		def conf = grailsApplication.config.grails.assets
 		def url  = attrs.file ?: attrs.src
 		def assetFound = false
@@ -71,7 +70,6 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	}
 
 	private assetUriRootPath() {
-		def context = grailsApplication.mainContext
 		def conf    = grailsApplication.config.grails.assets
 		def mapping = assetProcessorService.assetMapping
 		if(conf.url && conf.url instanceof Closure) {

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -13,12 +13,12 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	def assetProcessorService
 
 
-	CachingLinkGenerator(String serverUrl) {
+	CachingLinkGenerator(final String serverUrl) {
 		super(serverUrl)
 	}
 
 
-	String resource(Map attrs) {
+	String resource(final Map attrs) {
 		asset(attrs) ?: super.resource(attrs)
 	}
 
@@ -26,7 +26,7 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	 * Finds an Asset from the asset-pipeline based on the file attribute.
 	 * @param attrs [file]
 	 */
-	String asset(Map attrs) {
+	String asset(final Map attrs) {
 		assetProcessorService.asset(attrs, this)
 	}
 }

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -1,19 +1,25 @@
 package asset.pipeline.grails
 
+
+import asset.pipeline.AssetHelper
+import groovy.util.logging.Slf4j
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
-import asset.pipeline.AssetHelper
-import groovy.util.logging.Slf4j
+
 
 @Slf4j
 class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAware {
+
 	GrailsApplication grailsApplication
+
 	def assetProcessorService
+
 
 	LinkGenerator(String serverUrl) {
 		super(serverUrl)
 	}
+
 
 	String resource(Map attrs) {
 		return asset(attrs) ?: super.resource(attrs)
@@ -76,5 +82,4 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 			return conf.url ?: "/$mapping/"
 		}
 	}
-
 }

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -32,7 +32,6 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 	String asset(Map attrs) {
 		def absolutePath = handleAbsolute(attrs)
 
-		def absolute = attrs[DefaultLinkGenerator.ATTRIBUTE_ABSOLUTE]
 		def conf = grailsApplication.config.grails.assets
 		def url  = attrs.file ?: attrs.src
 		def assetFound = false
@@ -73,7 +72,6 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 	}
 
 	private assetUriRootPath() {
-		def context = grailsApplication.mainContext
 		def conf    = grailsApplication.config.grails.assets
 		def mapping = assetProcessorService.assetMapping
 		if(conf.url && conf.url instanceof Closure) {

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -21,7 +21,7 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 
 
 	String resource(Map attrs) {
-		return asset(attrs) ?: super.resource(attrs)
+		asset(attrs) ?: super.resource(attrs)
 	}
 
 	/**

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -1,7 +1,6 @@
 package asset.pipeline.grails
 
 
-import asset.pipeline.AssetHelper
 import groovy.util.logging.Slf4j
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
@@ -30,58 +29,6 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 	 * @param attrs [file]
 	 */
 	String asset(Map attrs) {
-		def absolutePath = handleAbsolute(attrs)
-
-		def conf = grailsApplication.config.grails.assets
-		def url  = attrs.file ?: attrs.src
-		def assetFound = false
-
-		if (url) {
-			if (conf.precompiled) {
-				def realPath = conf.manifest.getProperty(url)
-				if (realPath) {
-					url = assetUriRootPath() + realPath
-					assetFound = true
-				}
-			}
-			else {
-				def assetFile = AssetHelper.fileForFullName(url)
-				if (assetFile != null) {
-					url = assetUriRootPath() + url
-					assetFound = true
-				}
-			}
-		}
-
-		if (!assetFound) {
-			return null
-		}
-		else {
-			if (!url?.startsWith('http')) {
-				final contextPathAttribute = attrs.contextPath?.toString()
-				if (absolutePath == null) {
-					final cp = contextPathAttribute == null ? getContextPath() : contextPathAttribute
-					if (cp == null) {
-						absolutePath = handleAbsolute(absolute:true)
-					}
-					else {
-						absolutePath = cp
-					}
-				}
-				url = (absolutePath?:'') + (url ?: '')
-			}
-			return url
-		}
-	}
-
-	private assetUriRootPath() {
-		def conf    = grailsApplication.config.grails.assets
-		def mapping = assetProcessorService.assetMapping
-		if (conf.url && conf.url instanceof Closure) {
-			return conf.url.call(null)
-		}
-		else {
-			return conf.url ?: "/$mapping/"
-		}
+		assetProcessorService.asset(attrs, this)
 	}
 }

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -36,32 +36,35 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 		def url  = attrs.file ?: attrs.src
 		def assetFound = false
 
-		if(url) {
-			if(conf.precompiled) {
+		if (url) {
+			if (conf.precompiled) {
 				def realPath = conf.manifest.getProperty(url)
-				if(realPath) {
+				if (realPath) {
 					url = assetUriRootPath() + realPath
 					assetFound = true
 				}
-			} else {
+			}
+			else {
 				def assetFile = AssetHelper.fileForFullName(url)
-				if(assetFile != null) {
+				if (assetFile != null) {
 					url = assetUriRootPath() + url
 					assetFound = true
 				}
 			}
 		}
 
-		if(!assetFound) {
+		if (!assetFound) {
 			return null
-		} else {
-			if(!url?.startsWith('http')) {
+		}
+		else {
+			if (!url?.startsWith('http')) {
 				final contextPathAttribute = attrs.contextPath?.toString()
-				if(absolutePath == null) {
+				if (absolutePath == null) {
 					final cp = contextPathAttribute == null ? getContextPath() : contextPathAttribute
-					if(cp == null) {
+					if (cp == null) {
 						absolutePath = handleAbsolute(absolute:true)
-					} else {
+					}
+					else {
 						absolutePath = cp
 					}
 				}
@@ -74,9 +77,10 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 	private assetUriRootPath() {
 		def conf    = grailsApplication.config.grails.assets
 		def mapping = assetProcessorService.assetMapping
-		if(conf.url && conf.url instanceof Closure) {
+		if (conf.url && conf.url instanceof Closure) {
 			return conf.url.call(null)
-		} else {
+		}
+		else {
 			return conf.url ?: "/$mapping/"
 		}
 	}

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -2,15 +2,11 @@ package asset.pipeline.grails
 
 
 import groovy.util.logging.Slf4j
-import org.codehaus.groovy.grails.commons.GrailsApplication
-import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 
 
 @Slf4j
-class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAware {
-
-	GrailsApplication grailsApplication
+class LinkGenerator extends DefaultLinkGenerator {
 
 	def assetProcessorService
 

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -15,12 +15,12 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 	def assetProcessorService
 
 
-	LinkGenerator(String serverUrl) {
+	LinkGenerator(final String serverUrl) {
 		super(serverUrl)
 	}
 
 
-	String resource(Map attrs) {
+	String resource(final Map attrs) {
 		asset(attrs) ?: super.resource(attrs)
 	}
 
@@ -28,7 +28,7 @@ class LinkGenerator extends DefaultLinkGenerator implements GrailsApplicationAwa
 	 * Finds an Asset from the asset-pipeline based on the file attribute.
 	 * @param attrs [file]
 	 */
-	String asset(Map attrs) {
+	String asset(final Map attrs) {
 		assetProcessorService.asset(attrs, this)
 	}
 }

--- a/test/integration/asset/pipeline/grails/CachingLinkGeneratorSpec.groovy
+++ b/test/integration/asset/pipeline/grails/CachingLinkGeneratorSpec.groovy
@@ -26,7 +26,6 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
-            linkGenerator.grailsApplication = grailsApplication
             linkGenerator.assetProcessorService = assetProcessorService
 
             def filePath = "grails_logo.png"
@@ -40,7 +39,6 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
-            linkGenerator.grailsApplication = grailsApplication
             linkGenerator.assetProcessorService = assetProcessorService
 
             def filePath = "grails_logo.png"
@@ -55,7 +53,6 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             grailsApplication.config.grails.assets.precompiled = true
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
-            linkGenerator.grailsApplication = grailsApplication
             linkGenerator.assetProcessorService = assetProcessorService
             def filePath = "grails_logo.png"
             Properties manifestProperties = new Properties()
@@ -72,7 +69,6 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
-            linkGenerator.grailsApplication = grailsApplication
             linkGenerator.assetProcessorService = assetProcessorService
 
             def filePath = "fake_image.png"

--- a/test/integration/asset/pipeline/grails/LinkGeneratorSpec.groovy
+++ b/test/integration/asset/pipeline/grails/LinkGeneratorSpec.groovy
@@ -26,7 +26,6 @@ class LinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new LinkGenerator("http://localhost:8080")
-            linkGenerator.grailsApplication = grailsApplication
             linkGenerator.assetProcessorService = assetProcessorService
 
             def filePath = "grails_logo.png"
@@ -41,7 +40,6 @@ class LinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new LinkGenerator("http://localhost:8080")
-            linkGenerator.grailsApplication = grailsApplication
             linkGenerator.assetProcessorService = assetProcessorService
 
             def filePath = "grails_logo.png"
@@ -55,7 +53,6 @@ class LinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             grailsApplication.config.grails.assets.precompiled = true
             def linkGenerator = new LinkGenerator("http://localhost:8080")
-            linkGenerator.grailsApplication = grailsApplication
             linkGenerator.assetProcessorService = assetProcessorService
             def filePath = "grails_logo.png"
             Properties manifestProperties = new Properties()
@@ -72,7 +69,6 @@ class LinkGeneratorSpec extends IntegrationSpec {
         given: "A LinkGenerator and an image"
             grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new LinkGenerator("http://localhost:8080")
-            linkGenerator.grailsApplication = grailsApplication
             linkGenerator.assetProcessorService = assetProcessorService
 
             def filePath = "fake_image.png"

--- a/test/unit/asset/pipeline/grails/AssetMethodTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetMethodTagLibSpec.groovy
@@ -26,14 +26,14 @@ import asset.pipeline.fs.FileSystemAssetResolver
  */
 @TestFor(AssetMethodTagLib)
 class AssetMethodTagLibSpec extends Specification {
-  AssetProcessorService assetProcessorServiceMock = Mock(AssetProcessorService)
+  AssetProcessorService assetProcessorService = new AssetProcessorService()
 
   def setup() {
-
     AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('application','grails-app/assets'))
 
-    assetProcessorServiceMock.getAssetMapping() >> { "assets" }
-    tagLib.assetProcessorService = assetProcessorServiceMock
+    assetProcessorService.grailsApplication = grailsApplication
+
+    tagLib.assetProcessorService = assetProcessorService
   }
 
   void "should return assetPath"() {

--- a/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -25,17 +25,20 @@ import asset.pipeline.AssetPipelineConfigHolder
  */
 @TestFor(AssetsTagLib)
 class AssetsTagLibSpec extends Specification {
-  AssetProcessorService assetProcessorServiceMock = Mock(AssetProcessorService)
+  AssetProcessorService assetProcessorService = new AssetProcessorService()
   private static final LINE_BREAK = System.getProperty('line.separator') ?: '\n'
   private static MOCK_BASE_SERVER_URL = 'http://localhost:8080/foo'
 
   def setup() {
     AssetPipelineConfigHolder.registerResolver(new asset.pipeline.fs.FileSystemAssetResolver('application','grails-app/assets'))
-    assetProcessorServiceMock.getAssetMapping() >> { "assets" }
-    def assetMethodTagLibMock = mockTagLib(AssetMethodTagLib)
-    assetMethodTagLibMock.assetProcessorService = assetProcessorServiceMock
 
-    assetMethodTagLibMock.grailsLinkGenerator = [serverBaseURL: MOCK_BASE_SERVER_URL]
+    assetProcessorService.grailsApplication = grailsApplication
+
+    def assetMethodTagLibMock = mockTagLib(AssetMethodTagLib)
+    assetMethodTagLibMock.assetProcessorService = assetProcessorService
+    assetMethodTagLibMock.grailsLinkGenerator   = [serverBaseURL: MOCK_BASE_SERVER_URL]
+
+    tagLib.assetProcessorService = assetProcessorService
   }
 
   void "should return assetPath"() {
@@ -103,13 +106,13 @@ class AssetsTagLibSpec extends Specification {
       tagLib.image(src: assetSrc, width:'200',height:200) == '<img src="/assets/grails_logo.png" width="200" height="200"/>'
   }
 
-    void "should return image tag with absolute path"() {
-      given:
-        def assetSrc = "grails_logo.png"
+  void "should return image tag with absolute path"() {
+    given:
+      def assetSrc = "grails_logo.png"
 
-      expect:
-        tagLib.image(src: assetSrc, absolute: true) == "<img src=\"$MOCK_BASE_SERVER_URL/assets/grails_logo.png\" />"
-    }
+    expect:
+      tagLib.image(src: assetSrc, absolute: true) == "<img src=\"$MOCK_BASE_SERVER_URL/assets/grails_logo.png\" />"
+  }
 
   void "should return link tag"() {
     given:

--- a/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -93,10 +93,8 @@ class AssetsTagLibSpec extends Specification {
     when:
       // tagLib.out = stringWriter
       output = tagLib.stylesheet(src: assetSrc)
-
     then:
-      output == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css?compile=false"  />' + LINE_BREAK + '<link rel="stylesheet" href="/assets/asset-pipeline/test/test2.css?compile=false"  />' + LINE_BREAK
-
+      output == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css?compile=false" />' + LINE_BREAK + '<link rel="stylesheet" href="/assets/asset-pipeline/test/test2.css?compile=false" />' + LINE_BREAK
   }
 
   void "should return image tag"() {


### PR DESCRIPTION
This branch simplifies manifest reads.

It moves a lot of previously duplicated code into a single version in `AssetPipelineService`.

It simplifies the code, adds return types & variable types, etc.

It shouldn't make any functional changes, except one extraneous space is removed from the output of `<asset:stylesheet>`.