### PR TITLE
add link to release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Documentation
 -------------
 http://bertramdev.github.io/asset-pipeline
 
+Release Notes
+-------------
+https://bertramdev.github.io/asset-pipeline/guide/releases.html
+
 Things to be Done
 -----------------
 * Improve SourceMaps


### PR DESCRIPTION
I know it's part of the documentation, but generally it's in the README or a file in the root. It seems like an improvement to have a specific pointer for this in the README.

(sorry this isn't bundled in the other PR)