### PR TITLE
Issue 289:  Handle bundle taglib attribute as string. 

### DIFF
--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -22,6 +22,7 @@ class AssetsTagLib {
 	 */
 	def javascript = {attrs ->
 		def src = attrs.remove('src')
+		def attrBundle = attrs.remove('bundle')
 		attrs.remove('href')
 		src = "${AssetHelper.nameWithoutExtension(src)}.js"
 		def uri
@@ -29,7 +30,7 @@ class AssetsTagLib {
 
 		def conf = grailsApplication.config.grails.assets
 
-		def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrs.bundle != true)
+		def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrBundle != 'true')
 
 		if(!nonBundledMode) {
 			out << "<script src=\"${assetPath(src:src)}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>"
@@ -63,6 +64,7 @@ class AssetsTagLib {
 	 */
 	def stylesheet = {attrs ->
 		def src  = attrs.remove('src')
+		def attrBundle = attrs.remove('bundle')
 		def href = attrs.remove('href')
 		if (href) {
 			src = href
@@ -71,7 +73,7 @@ class AssetsTagLib {
 		def conf = grailsApplication.config.grails.assets
 		def uri
 		def extension
-		def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrs.bundle != true)
+		def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrBundle != 'true')
 
 		if(!nonBundledMode) {
 			out << link([rel: 'stylesheet', href:src] + attrs)

--- a/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -56,6 +56,16 @@ class AssetsTagLibSpec extends Specification {
       tagLib.javascript(src: assetSrc) == '<script src="/assets/asset-pipeline/test/test.js" type="text/javascript" ></script>'
   }
 
+  void "should always return javascript link tag when bundle attr is 'true'"() {
+    given:
+      grailsApplication.config.grails.assets.bundle = false
+      grailsApplication.config.grails.assets.allowDebugParam = true
+      params."_debugAssets" = "y"
+      def assetSrc = "asset-pipeline/test/test.js"
+    expect:
+      tagLib.javascript(src: assetSrc, bundle: 'true') == '<script src="/assets/asset-pipeline/test/test.js" type="text/javascript" ></script>'
+  }
+
   void "should return javascript link tag with seperated files when debugMode is on"() {
     given:
       grailsApplication.config.grails.assets.bundle = false
@@ -79,6 +89,16 @@ class AssetsTagLibSpec extends Specification {
       def assetSrc = "asset-pipeline/test/test.css"
     expect:
       tagLib.stylesheet(href: assetSrc) == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css"/>'
+  }
+
+  void "should always return stylesheet link tag when bundle attr is 'true'"() {
+    given:
+      grailsApplication.config.grails.assets.bundle = false
+      grailsApplication.config.grails.assets.allowDebugParam = true
+      params."_debugAssets" = "y"
+      def assetSrc = "asset-pipeline/test/test.css"
+    expect:
+      tagLib.stylesheet(href: assetSrc, bundle: 'true') == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css"/>'
   }
 
   void "should return stylesheet link tag with seperated files when debugMode is on"() {


### PR DESCRIPTION
Also, remove bundle attr to prevent it from being rendered back out.