### PR TITLE
Many changes...

### DIFF
--- a/AssetPipelineGrailsPlugin.groovy
+++ b/AssetPipelineGrailsPlugin.groovy
@@ -83,7 +83,7 @@ class AssetPipelineGrailsPlugin {
         }
 
         if(!assetsConfig.containsKey("precompiled")) {
-            assetsConfig.precompiled = application.warDeployed
+            assetsConfig.precompiled = application.warDeployed || assetsConfig.url
         }
 
 

--- a/AssetPipelineGrailsPlugin.groovy
+++ b/AssetPipelineGrailsPlugin.groovy
@@ -82,10 +82,6 @@ class AssetPipelineGrailsPlugin {
             }
         }
 
-        if(!assetsConfig.containsKey("precompiled")) {
-            assetsConfig.precompiled = application.warDeployed || assetsConfig.url
-        }
-
 
         AssetPipelineConfigHolder.config = assetsConfig
 

--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -1,15 +1,32 @@
 import asset.pipeline.AssetPipelineConfigHolder
+import com.grailsrocks.jqueryui.JqueryUiTagLib
+import java.util.Map.Entry
+import javax.servlet.ServletContext
+import javax.servlet.http.HttpServletRequest
+import org.codehaus.groovy.grails.plugins.web.taglib.ApplicationTagLib
+import org.grails.plugin.resource.ResourceTagLib
 import org.springframework.context.ApplicationContext
 import org.springframework.core.io.Resource
+
+import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
+import static org.codehaus.groovy.grails.web.util.WebUtils.retrieveGrailsWebRequest
 
 
 class AssetPipelineBootStrap {
 
+	private static final int SLASH = (int) '/' as char
+
+
 	def assetProcessorService
 	def grailsApplication
+	def pluginManager
 
 
-	def init = {final servletContext ->
+	def init = {final ServletContext servletContext ->
+		wrapLinkWriters((Map<String, Closure<String>>) ApplicationTagLib.LINK_WRITERS, '/plugins/')
+		wrapLinkWriters((Map<String, Closure<String>>)    JqueryUiTagLib.LINK_WRITERS, '/plugins/')
+		wrapLinkWriters((Map<String, Closure<String>>)    ResourceTagLib.LINK_WRITERS, "/${pluginManager.getGrailsPlugin('resources').instance.getUriPrefix(grailsApplication)}/plugins/")
+
 		final ConfigObject conf = grailsApplication.config.grails.assets
 
 		final def storagePath = conf.storagePath
@@ -64,6 +81,43 @@ class AssetPipelineBootStrap {
 
 				manifest.store(new File(storageDir, 'manifest.properties').newWriter(), '')
 			}
+		}
+	}
+
+
+	private static void wrapLinkWriters(final Map<String, Closure<String>> linkWriterByName, final String removeUriPrefix) {
+		for (final Entry<String, Closure<String>> linkWriterForName : linkWriterByName.entrySet()) {
+			linkWriterForName.value = wrapLinkWriter(linkWriterForName.value, removeUriPrefix)
+		}
+	}
+
+	private static Closure<String> wrapLinkWriter(final Closure<String> linkWriter, final String removeUriPrefix) {
+		{final String url, final Map<String, String> constants, final Map<String, ?> attrs ->
+			final int indexSlash3
+			final int indexAfterSlash3
+			final int indexSlash4
+
+			final String assetUrl =
+				url.startsWith(removeUriPrefix) &&
+				(indexSlash3      = url.indexOf(SLASH, removeUriPrefix.length())) != -1 &&
+				(indexAfterSlash3 = indexSlash3 + 1)                              != url.length() &&
+				(indexSlash4      = url.indexOf(SLASH, indexAfterSlash3))         != -1 \
+					? url.substring(indexSlash4 + 1)
+					: url
+
+			final HttpServletRequest req = retrieveGrailsWebRequest().currentRequest
+
+			final String assetPipelineBaseUrl
+			linkWriter(
+				(
+					assetProcessorService.isAssetPath(assetUrl) &&
+					(assetPipelineBaseUrl = assetProcessorService.getConfigBaseUrl(req)) != null
+						? assetPipelineBaseUrl + assetUrl
+						: getBaseUrlWithScheme(req).append(url).toString()
+				),
+				constants,
+				attrs
+			)
 		}
 	}
 }

--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -1,32 +1,16 @@
 import asset.pipeline.AssetPipelineConfigHolder
-import com.grailsrocks.jqueryui.JqueryUiTagLib
-import java.util.Map.Entry
 import javax.servlet.ServletContext
-import javax.servlet.http.HttpServletRequest
-import org.codehaus.groovy.grails.plugins.web.taglib.ApplicationTagLib
-import org.grails.plugin.resource.ResourceTagLib
 import org.springframework.context.ApplicationContext
 import org.springframework.core.io.Resource
-
-import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
-import static org.codehaus.groovy.grails.web.util.WebUtils.retrieveGrailsWebRequest
 
 
 class AssetPipelineBootStrap {
 
-	private static final int SLASH = (int) '/' as char
-
-
 	def assetProcessorService
 	def grailsApplication
-	def pluginManager
 
 
 	def init = {final ServletContext servletContext ->
-		wrapLinkWriters((Map<String, Closure<String>>) ApplicationTagLib.LINK_WRITERS, '/plugins/')
-		wrapLinkWriters((Map<String, Closure<String>>)    JqueryUiTagLib.LINK_WRITERS, '/plugins/')
-		wrapLinkWriters((Map<String, Closure<String>>)    ResourceTagLib.LINK_WRITERS, "/${pluginManager.getGrailsPlugin('resources').instance.getUriPrefix(grailsApplication)}/plugins/")
-
 		final ConfigObject conf = grailsApplication.config.grails.assets
 
 		final def storagePath = conf.storagePath
@@ -81,43 +65,6 @@ class AssetPipelineBootStrap {
 
 				manifest.store(new File(storageDir, 'manifest.properties').newWriter(), '')
 			}
-		}
-	}
-
-
-	private static void wrapLinkWriters(final Map<String, Closure<String>> linkWriterByName, final String removeUriPrefix) {
-		for (final Entry<String, Closure<String>> linkWriterForName : linkWriterByName.entrySet()) {
-			linkWriterForName.value = wrapLinkWriter(linkWriterForName.value, removeUriPrefix)
-		}
-	}
-
-	private static Closure<String> wrapLinkWriter(final Closure<String> linkWriter, final String removeUriPrefix) {
-		{final String url, final Map<String, String> constants, final Map<String, ?> attrs ->
-			final int indexSlash3
-			final int indexAfterSlash3
-			final int indexSlash4
-
-			final String assetUrl =
-				url.startsWith(removeUriPrefix) &&
-				(indexSlash3      = url.indexOf(SLASH, removeUriPrefix.length())) != -1 &&
-				(indexAfterSlash3 = indexSlash3 + 1)                              != url.length() &&
-				(indexSlash4      = url.indexOf(SLASH, indexAfterSlash3))         != -1 \
-					? url.substring(indexSlash4 + 1)
-					: url
-
-			final HttpServletRequest req = retrieveGrailsWebRequest().currentRequest
-
-			final String assetPipelineBaseUrl
-			linkWriter(
-				(
-					assetProcessorService.isAssetPath(assetUrl) &&
-					(assetPipelineBaseUrl = assetProcessorService.getConfigBaseUrl(req)) != null
-						? assetPipelineBaseUrl + assetUrl
-						: getBaseUrlWithScheme(req).append(url).toString()
-				),
-				constants,
-				attrs
-			)
 		}
 	}
 }

--- a/grails-app/conf/AssetPipelineBootStrap.groovy
+++ b/grails-app/conf/AssetPipelineBootStrap.groovy
@@ -5,11 +5,14 @@ import org.springframework.core.io.Resource
 
 class AssetPipelineBootStrap {
 
+	def assetProcessorService
 	def grailsApplication
 
 
 	def init = {final servletContext ->
-		final def storagePath = grailsApplication.config.grails.assets.storagePath
+		final ConfigObject conf = grailsApplication.config.grails.assets
+
+		final def storagePath = conf.storagePath
 		if (! storagePath) {
 			return
 		}
@@ -17,36 +20,50 @@ class AssetPipelineBootStrap {
 		final Properties manifest = AssetPipelineConfigHolder.manifest
 
 		if (manifest) {
-			final File storageDir = new File((String) storagePath)
-			storageDir.mkdirs()
+			final boolean enableDigests  = assetProcessorService.isEnableDigests(conf)
+			final boolean skipNonDigests = assetProcessorService.isSkipNonDigests(conf)
 
-			final ApplicationContext parentContext = grailsApplication.parentContext
+			if (enableDigests || ! skipNonDigests) {
+				final File storageDir = new File((String) storagePath)
+				storageDir.mkdirs()
 
-			manifest.stringPropertyNames().each {final String propertyName ->
-				final File outputFile = new File(storageDir, propertyName)
+				final ApplicationContext parentContext = grailsApplication.parentContext
 
-				new File(outputFile.parent).mkdirs()
+				manifest.stringPropertyNames().each {final String propertyName ->
+					final File outputFile = new File(storageDir, propertyName)
 
-				final String propertyValue = manifest.getProperty(propertyName)
+					new File(outputFile.parent).mkdirs()
 
-				final String assetPath = "assets/${propertyValue}"
+					final String propertyValue = manifest.getProperty(propertyName)
 
-				final byte[] fileBytes = parentContext.getResource(assetPath).inputStream.bytes
+					final String assetPath = "assets/${enableDigests ? propertyValue : propertyName}"
 
-				outputFile.bytes = fileBytes
+					final byte[] fileBytes = parentContext.getResource(assetPath).inputStream.bytes
 
-				new File(storageDir, propertyValue).bytes = fileBytes
+					if (! skipNonDigests) {
+						outputFile.bytes = fileBytes
+					}
 
-				final Resource gzRes = parentContext.getResource("${assetPath}.gz")
-				if (gzRes.exists()) {
-					final byte[] gzBytes = gzRes.inputStream.bytes
+					if (enableDigests) {
+						new File(storageDir, propertyValue).bytes = fileBytes
+					}
 
-					new File(storageDir, "${propertyName}.gz" ).bytes = gzBytes
-					new File(storageDir, "${propertyValue}.gz").bytes = gzBytes
+					final Resource gzRes = parentContext.getResource("${assetPath}.gz")
+					if (gzRes.exists()) {
+						final byte[] gzBytes = gzRes.inputStream.bytes
+
+						if (! skipNonDigests) {
+							new File(storageDir, "${propertyName}.gz" ).bytes = gzBytes
+						}
+
+						if (enableDigests) {
+							new File(storageDir, "${propertyValue}.gz").bytes = gzBytes
+						}
+					}
 				}
-			}
 
-			manifest.store(new File(storageDir, 'manifest.properties').newWriter(), '')
+				manifest.store(new File(storageDir, 'manifest.properties').newWriter(), '')
+			}
 		}
 	}
 }

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -29,10 +29,7 @@ grails {
 
 				plugins {
 					test    name: 'code-coverage',       version: '1.2.7',  {export = false}
-					compile name: 'jquery',              version: '1.11.1', {export = false}
-					compile name: 'jquery-ui',           version: '1.10.4', {export = false}
 					build   name: 'release',             version: '3.1.1',  {export = false}
-					compile name: 'resources',           version: '1.2.14', {export = false}
 					build   name: 'rest-client-builder', version: '2.0.1',  {export = false}
 					compile name: 'webxml',              version: '1.4.1'
 				}

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,39 +1,42 @@
-grails.project.work.dir = 'target'
+grails {
+	project {
+		source.level = 1.7
+		target.level = 1.7
 
-grails.project.dependency.resolver = "maven"
-grails.project.target.level = 1.7
-grails.project.source.level = 1.7
+		work.dir = 'target'
 
-grails.project.dependency.resolution = {
+		dependency {
+			resolver = 'maven'
 
-    inherits 'global'
-    log 'warn'
+			resolution = {
+				inherits 'global'
+				log      'warn'
 
-    repositories {
-        mavenLocal()
-        grailsCentral()
-        mavenCentral()
-        jcenter()
-        mavenRepo "http://dl.bintray.com/bertramlabs/asset-pipeline"
-    }
+				repositories {
+					mavenLocal()
+					grailsCentral()
+					mavenCentral()
+					jcenter()
+					mavenRepo 'http://dl.bintray.com/bertramlabs/asset-pipeline'
+				}
 
-    dependencies {
-        runtime 'org.mozilla:rhino:1.7R4'
-        compile("com.bertramlabs.plugins:asset-pipeline-core:2.5.8")
-        //Temporary inclusion due to bug in 2.4.2
-        compile("cglib:cglib-nodep:2.2.2") {
-            export = false
-        }
-    }
+				dependencies {
+					// Temporary inclusion due to bug in 2.4.2
+					compile group: 'cglib',                   name: 'cglib-nodep',         version: '2.2.2', {export = false}
+					compile group: 'com.bertramlabs.plugins', name: 'asset-pipeline-core', version: '2.5.8'
+					runtime group: 'org.mozilla',             name: 'rhino',               version: '1.7R4'
+				}
 
-    plugins {
-        compile(":webxml:1.4.1")
-
-        build ':release:3.1.1', ':rest-client-builder:2.0.1', {
-            export = false
-        }
-        test ":code-coverage:1.2.7", {
-            export = false
-        }
-    }
+				plugins {
+					test    name: 'code-coverage',       version: '1.2.7',  {export = false}
+					compile name: 'jquery',              version: '1.11.1', {export = false}
+					compile name: 'jquery-ui',           version: '1.10.4', {export = false}
+					build   name: 'release',             version: '3.1.1',  {export = false}
+					compile name: 'resources',           version: '1.2.14', {export = false}
+					build   name: 'rest-client-builder', version: '2.0.1',  {export = false}
+					compile name: 'webxml',              version: '1.4.1'
+				}
+			}
+		}
+	}
 }

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -4,11 +4,15 @@ package asset.pipeline.grails
 import asset.pipeline.AssetPipelineConfigHolder
 import javax.servlet.http.HttpServletRequest
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
+import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 
 import static asset.pipeline.AssetHelper.fileForFullName
+import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
 import static asset.pipeline.grails.utils.text.StringBuilders.ensureEndsWith
 import static asset.pipeline.utils.net.Urls.hasAuthority
+import static grails.util.Environment.isWarDeployed
 import static org.apache.commons.lang.StringUtils.trimToEmpty
+import static org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest.lookup
 
 
 class AssetProcessorService {
@@ -145,6 +149,21 @@ class AssetProcessorService {
 				.append(mapping)
 				.append('/' as char)
 				.toString()
+	}
+
+
+	String makeServerURL(final DefaultLinkGenerator linkGenerator) {
+		String serverUrl = linkGenerator.configuredServerBaseURL
+		if (! serverUrl) {
+			final GrailsWebRequest req = lookup()
+			if (req) {
+				serverUrl = getBaseUrlWithScheme(req.currentRequest).toString()
+				if (! serverUrl && ! warDeployed) {
+					serverUrl = "http://localhost:${System.getProperty('server.port') ?: '8080'}${linkGenerator.contextPath ?: ''}"
+				}
+			}
+		}
+		return serverUrl
 	}
 
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -35,8 +35,16 @@ class AssetProcessorService {
 	}
 
 
+	boolean isEnableDigests(final ConfigObject conf = grailsApplication.config.grails.assets) {
+		conf.containsKey('enableDigests') ? conf.enableDigests : true
+	}
+
+	boolean isSkipNonDigests(final ConfigObject conf = grailsApplication.config.grails.assets) {
+		conf.containsKey('skipNonDigests') ? conf.skipNonDigests : true
+	}
+
 	boolean shouldUseManifestPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		path && AssetPipelineConfigHolder.manifest
+		path && AssetPipelineConfigHolder.manifest && isEnableDigests(conf)
 	}
 
 

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,10 +1,14 @@
 package asset.pipeline.grails
 
 
+import asset.pipeline.AssetPipelineConfigHolder
+import javax.servlet.http.HttpServletRequest
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 
 import static asset.pipeline.AssetHelper.fileForFullName
-import asset.pipeline.AssetPipelineConfigHolder
+import static asset.pipeline.grails.utils.text.StringBuilders.ensureEndsWith
+import static asset.pipeline.utils.net.Urls.hasAuthority
+import static org.apache.commons.lang.StringUtils.trimToEmpty
 
 
 class AssetProcessorService {
@@ -13,6 +17,7 @@ class AssetProcessorService {
 
 
 	def grailsApplication
+	def grailsLinkGenerator
 
 
 	/**
@@ -23,15 +28,14 @@ class AssetProcessorService {
 	 * @throws IllegalArgumentException if the path contains <code>/</code>
 	 */
 	String getAssetMapping() {
-		def path = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
-		if (path.contains('/')) {
+		final def mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
+		if (mapping.contains('/')) {
 			throw new IllegalArgumentException(
 				'The property [grails.assets.mapping] can only be one level deep.  ' +
 				"For example, 'foo' and 'bar' would be acceptable values, but 'foo/bar' is not"
 			)
 		}
-
-		return path
+		return mapping
 	}
 
 
@@ -43,46 +47,54 @@ class AssetProcessorService {
 		conf.containsKey('skipNonDigests') ? conf.skipNonDigests : true
 	}
 
-	boolean shouldUseManifestPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		path && AssetPipelineConfigHolder.manifest && isEnableDigests(conf)
-	}
-
 
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		shouldUseManifestPath(path, conf) \
-			? AssetPipelineConfigHolder.manifest.getProperty(path) ?: path
-			: path
+		final String relativePath = trimLeadingSlash(path)
+		relativePath && AssetPipelineConfigHolder.manifest && isEnableDigests(conf) \
+			? AssetPipelineConfigHolder.manifest.getProperty(relativePath) ?: relativePath
+			: relativePath
 	}
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		shouldUseManifestPath(path, conf) \
-			? AssetPipelineConfigHolder.manifest.getProperty(path)
-			: fileForFullName(path) != null \
-				? path
-				: null
+		final String relativePath = trimLeadingSlash(path)
+		relativePath \
+			? AssetPipelineConfigHolder.manifest \
+				? isEnableDigests(conf) \
+					? AssetPipelineConfigHolder.manifest.getProperty(relativePath)
+					: AssetPipelineConfigHolder.manifest.getProperty(relativePath) \
+						? relativePath
+						: null
+				: fileForFullName(relativePath) != null \
+					? relativePath
+					: null
+			: null
 	}
 
 
 	boolean isAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		shouldUseManifestPath(path, conf) \
-			? AssetPipelineConfigHolder.manifest.getProperty(path)
-			: path && fileForFullName(path) != null
+		final String relativePath = trimLeadingSlash(path)
+		relativePath &&
+		(
+			AssetPipelineConfigHolder.manifest \
+				? AssetPipelineConfigHolder.manifest.getProperty(relativePath)
+				: fileForFullName(relativePath) != null
+		)
 	}
 
 
 	String asset(final Map attrs, final DefaultLinkGenerator linkGenerator) {
-		def absolutePath = linkGenerator.handleAbsolute(attrs)
-
 		String url = getResolvedAssetPath(attrs.file ?: attrs.src)
 
-		if (!url) {
+		if (! url) {
 			return null
 		}
 
-		url = assetUriRootPath() + url
+		url = assetBaseUrl(null, false) + url
 
-		if (!url.startsWith('http')) {
+		if (! hasAuthority(url)) {
+			def absolutePath = linkGenerator.handleAbsolute(attrs)
+
 			if (absolutePath == null) {
 				final String contextPathAttribute = attrs.contextPath?.toString()
 
@@ -103,10 +115,42 @@ class AssetProcessorService {
 		return url
 	}
 
-	private String assetUriRootPath() {
-		final def url = grailsApplication.config.grails.assets.url
+	String getConfigBaseUrl(final HttpServletRequest req, final ConfigObject conf = grailsApplication.config.grails.assets) {
+		final def url = conf.url
 		url instanceof Closure \
-			? url.call(null)
-			: url ?: "/$assetMapping/"
+			? url(req)
+			: url \
+				? url
+				: null
+	}
+
+	String assetBaseUrl(final HttpServletRequest req, final boolean prependServerBaseUrlIfNoAssetBaseUrlSet, final ConfigObject conf = grailsApplication.config.grails.assets) {
+		final String url = getConfigBaseUrl(req, conf)
+		if (url) {
+			return url
+		}
+
+		final String mapping = assetMapping
+
+		final String baseUrl =
+			prependServerBaseUrlIfNoAssetBaseUrlSet \
+				? grailsLinkGenerator.serverBaseURL ?: ''
+				: trimToEmpty(grailsLinkGenerator.contextPath)
+
+		return \
+			ensureEndsWith(
+				new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl),
+				'/' as char
+			)
+				.append(mapping)
+				.append('/' as char)
+				.toString()
+	}
+
+
+	private static String trimLeadingSlash(final String s) {
+		! s || s.charAt(0) != '/' as char \
+			? s
+			: s.substring(1)
 	}
 }

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -76,7 +76,7 @@ class AssetProcessorService {
 	}
 
 
-	boolean isAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+	boolean isAssetPath(final String path) {
 		final String relativePath = trimLeadingSlash(path)
 		relativePath &&
 		(

--- a/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,12 +1,12 @@
 package asset.pipeline.grails
 
 
-import asset.pipeline.AssetPipelineConfigHolder
 import javax.servlet.http.HttpServletRequest
 import org.codehaus.groovy.grails.web.mapping.DefaultLinkGenerator
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 
 import static asset.pipeline.AssetHelper.fileForFullName
+import static asset.pipeline.AssetPipelineConfigHolder.manifest
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
 import static asset.pipeline.grails.utils.text.StringBuilders.ensureEndsWith
 import static asset.pipeline.utils.net.Urls.hasAuthority
@@ -54,8 +54,8 @@ class AssetProcessorService {
 
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
-		relativePath && AssetPipelineConfigHolder.manifest && isEnableDigests(conf) \
-			? AssetPipelineConfigHolder.manifest.getProperty(relativePath) ?: relativePath
+		relativePath && manifest && isEnableDigests(conf) \
+			? manifest.getProperty(relativePath) ?: relativePath
 			: relativePath
 	}
 
@@ -63,10 +63,10 @@ class AssetProcessorService {
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		relativePath \
-			? AssetPipelineConfigHolder.manifest \
+			? manifest \
 				? isEnableDigests(conf) \
-					? AssetPipelineConfigHolder.manifest.getProperty(relativePath)
-					: AssetPipelineConfigHolder.manifest.getProperty(relativePath) \
+					? manifest.getProperty(relativePath)
+					: manifest.getProperty(relativePath) \
 						? relativePath
 						: null
 				: fileForFullName(relativePath) != null \
@@ -80,8 +80,8 @@ class AssetProcessorService {
 		final String relativePath = trimLeadingSlash(path)
 		relativePath &&
 		(
-			AssetPipelineConfigHolder.manifest \
-				? AssetPipelineConfigHolder.manifest.getProperty(relativePath)
+			manifest \
+				? manifest.getProperty(relativePath)
 				: fileForFullName(relativePath) != null
 		)
 	}

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -1,9 +1,6 @@
 package asset.pipeline.grails
 
 
-import static org.apache.commons.lang.StringUtils.trimToEmpty
-
-
 class AssetMethodTagLib {
 
 	static namespace = 'g'
@@ -11,8 +8,6 @@ class AssetMethodTagLib {
 
 
 	def assetProcessorService
-	def grailsApplication
-	def grailsLinkGenerator
 
 
 	def assetPath = {final def attrs ->
@@ -30,27 +25,6 @@ class AssetMethodTagLib {
 			absolute = false
 		}
 
-		return assetUriRootPath(absolute) + assetProcessorService.getAssetPath(src)
-	}
-
-	private String assetUriRootPath(final boolean absolute) {
-		final String mapping = assetProcessorService.assetMapping
-
-		def configUrl = grailsApplication.config.grails.assets.url
-
-		if (configUrl instanceof Closure) {
-			configUrl = configUrl.call(request)
-		}
-
-		if (configUrl) {
-			return configUrl
-		}
-		else if (absolute) {
-			return [grailsLinkGenerator.serverBaseURL, "$mapping/"].join('/')
-		}
-
-		final String contextPath = trimToEmpty(grailsLinkGenerator.contextPath)
-
-		return contextPath + "${contextPath.endsWith('/') ? '' : '/'}$mapping/"
+		return assetProcessorService.assetBaseUrl(request, absolute) + assetProcessorService.getAssetPath(src)
 	}
 }

--- a/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -16,14 +16,17 @@ class AssetMethodTagLib {
 
 
 	def assetPath = {final def attrs ->
-		final def src
+		final def     src
 		final boolean absolute
+
 		if (attrs instanceof Map) {
 			src = attrs.src
-			absolute = attrs.containsKey('absolute') ? attrs.absolute : false
+
+			final def abs = attrs.absolute
+			absolute = abs != null ? abs : false
 		}
 		else {
-			src = attrs
+			src      = attrs
 			absolute = false
 		}
 

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -22,9 +22,10 @@ class AssetsTagLib {
 	 * @attr src REQUIRED
 	 */
 	def javascript = {final attrs ->
+		final GrailsPrintWriter outPw = out
 		attrs.remove('href')
 		element(attrs, 'js', 'application/javascript', null) {final String src, final outputAttrs, final String endOfLine ->
-			out << '<script type="text/javascript" src="' << src << '" ' << paramsToHtmlAttr(outputAttrs) << '></script>' << endOfLine
+			outPw << '<script type="text/javascript" src="' << src << '" ' << paramsToHtmlAttr(outputAttrs) << '></script>' << endOfLine
 		}
 	}
 
@@ -33,12 +34,13 @@ class AssetsTagLib {
 	 * @attr src OPTIONAL alternative to href
 	 */
 	def stylesheet = {final attrs ->
+		final GrailsPrintWriter outPw = out
 		element(attrs, 'css', 'text/css', Objects.toString(attrs.remove('href'), null)) {final String src, final outputAttrs, final String endOfLine ->
-			if (''.equals(endOfLine)) {
-				out << link([rel: 'stylesheet', href: src] + outputAttrs)
+			if (endOfLine) {
+				outPw << '<link rel="stylesheet" href="' << src << '" ' << paramsToHtmlAttr(outputAttrs) << '/>' << endOfLine
 			}
 			else {
-				out << '<link rel="stylesheet" href="' << src << '" ' << paramsToHtmlAttr(outputAttrs) << '/>' << endOfLine
+				outPw << link([rel: 'stylesheet', href: src] + outputAttrs)
 			}
 		}
 	}

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -74,8 +74,8 @@ class AssetsTagLib {
 				attrs.charset \
 					? "?compile=false&encoding=${attrs.charset}"
 					: '?compile=false'
-			AssetPipeline.getDependencyList(uri, contentType, extension).each {
-				output("${it.path}", queryString, attrs, LINE_BREAK)
+			AssetPipeline.getDependencyList(uri, contentType, extension)?.each {
+				output(it.path, queryString, attrs, LINE_BREAK)
 			}
 		}
 	}

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -3,6 +3,7 @@ package asset.pipeline.grails
 
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipeline
+import org.codehaus.groovy.grails.web.util.GrailsPrintWriter
 
 
 class AssetsTagLib {
@@ -20,41 +21,10 @@ class AssetsTagLib {
 	/**
 	 * @attr src REQUIRED
 	 */
-	def javascript = {attrs ->
-		def src = attrs.remove('src')
-		def attrBundle = attrs.remove('bundle')
+	def javascript = {final attrs ->
 		attrs.remove('href')
-		src = "${AssetHelper.nameWithoutExtension(src)}.js"
-		def uri
-		def extension
-
-		def conf = grailsApplication.config.grails.assets
-
-		def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrBundle != 'true')
-
-		if(!nonBundledMode) {
-			out << "<script src=\"${assetPath(src:src)}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>"
-		}
-		else {
-			if (src.lastIndexOf('.') >= 0) {
-				uri = src.substring(0, src.lastIndexOf('.'))
-				extension = src.substring(src.lastIndexOf('.') + 1)
-			}
-			else {
-				uri = src
-				extension = 'js'
-			}
-			// def startTime = new Date().time
-			def list = AssetPipeline.getDependencyList(uri, 'application/javascript', extension)
-			def modifierParams = ['compile=false']
-			if (attrs.charset) {
-				modifierParams << "encoding=${attrs.charset}"
-			}
-			list.each {dep ->
-				def depAssetPath = assetPath([src: "${dep.path}", ignorePrefix:true])
-				out << "<script src=\"${depAssetPath}?${modifierParams.join('&')}\" type=\"text/javascript\" ${paramsToHtmlAttr(attrs)}></script>${LINE_BREAK}"
-			}
-			// println "Fetching Dev Mode Dependency List Time ${new Date().time - startTime}"
+		element(attrs, 'js', 'application/javascript', null) {final String src, final outputAttrs, final String endOfLine ->
+			out << '<script type="text/javascript" src="' << src << '" ' << paramsToHtmlAttr(outputAttrs) << '></script>' << endOfLine
 		}
 	}
 
@@ -62,39 +32,46 @@ class AssetsTagLib {
 	 * @attr href OPTIONAL alternative to src
 	 * @attr src OPTIONAL alternative to href
 	 */
-	def stylesheet = {attrs ->
-		def src  = attrs.remove('src')
-		def attrBundle = attrs.remove('bundle')
-		def href = attrs.remove('href')
-		if (href) {
-			src = href
-		}
-		src = "${AssetHelper.nameWithoutExtension(src)}.css"
-		def conf = grailsApplication.config.grails.assets
-		def uri
-		def extension
-		def nonBundledMode = (!grailsApplication.warDeployed && conf.bundle != true && attrBundle != 'true')
-
-		if(!nonBundledMode) {
-			out << link([rel: 'stylesheet', href:src] + attrs)
-		}
-		else {
-			if (src.lastIndexOf('.') >= 0) {
-				uri = src.substring(0, src.lastIndexOf('.'))
-				extension = src.substring(src.lastIndexOf('.') + 1)
+	def stylesheet = {final attrs ->
+		element(attrs, 'css', 'text/css', Objects.toString(attrs.remove('href'), null)) {final String src, final outputAttrs, final String endOfLine ->
+			if (''.equals(endOfLine)) {
+				out << link([rel: 'stylesheet', href: src] + outputAttrs)
 			}
 			else {
-				uri = src
-				extension = 'css'
+				out << '<link rel="stylesheet" href="' << src << '" ' << paramsToHtmlAttr(outputAttrs) << '/>' << endOfLine
 			}
-			def list = AssetPipeline.getDependencyList(uri, 'text/css', extension)
-			def modifierParams = ['compile=false']
+		}
+	}
+
+	private void element(final attrs, final String ext, final String contentType, final String srcOverride, final Closure<GrailsPrintWriter> output) {
+		def src = attrs.remove('src')
+		if (srcOverride) {
+			src = srcOverride
+		}
+		src = "${AssetHelper.nameWithoutExtension(src)}.${ext}"
+
+		final def nonBundledMode = (!grailsApplication.warDeployed && grailsApplication.config.grails.assets.bundle != true && attrs.remove('bundle') != 'true')
+		if (! nonBundledMode) {
+			output(assetPath(src: src), attrs, '')
+		}
+		else {
+			final int lastDotIndex = src.lastIndexOf('.')
+			final def uri
+			final def extension
+			if (lastDotIndex >= 0) {
+				uri       = src.substring(0, lastDotIndex)
+				extension = src.substring(lastDotIndex + 1)
+			}
+			else {
+				uri       = src
+				extension = ext
+			}
+			final def modifierParams = ['compile=false']
 			if (attrs.charset) {
 				modifierParams << "encoding=${attrs.charset}"
 			}
-			list.each {dep ->
-				def depAssetPath = assetPath([src: "${dep.path}", ignorePrefix:true])
-				out << "<link rel=\"stylesheet\" href=\"${depAssetPath}?${modifierParams.join('&')}\" ${paramsToHtmlAttr(attrs)}/>${LINE_BREAK}"
+			AssetPipeline.getDependencyList(uri, contentType, extension).each {
+				output("${assetPath([src: "${it.path}", ignorePrefix: true])}?${modifierParams.join('&')}", attrs, LINE_BREAK)
 			}
 		}
 	}

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -24,8 +24,8 @@ class AssetsTagLib {
 	def javascript = {final attrs ->
 		final GrailsPrintWriter outPw = out
 		attrs.remove('href')
-		element(attrs, 'js', 'application/javascript', null) {final String src, final outputAttrs, final String endOfLine ->
-			outPw << '<script type="text/javascript" src="' << src << '" ' << paramsToHtmlAttr(outputAttrs) << '></script>' << endOfLine
+		element(attrs, 'js', 'application/javascript', null) {final String src, final String queryString, final outputAttrs, final String endOfLine ->
+			outPw << '<script type="text/javascript" src="' << assetPath(src: src) << queryString << '" ' << paramsToHtmlAttr(outputAttrs) << '></script>' << endOfLine
 		}
 	}
 
@@ -37,12 +37,12 @@ class AssetsTagLib {
 	 */
 	def stylesheet = {final attrs ->
 		final GrailsPrintWriter outPw = out
-		element(attrs, 'css', 'text/css', Objects.toString(attrs.remove('href'), null)) {final String src, final outputAttrs, final String endOfLine ->
+		element(attrs, 'css', 'text/css', Objects.toString(attrs.remove('href'), null)) {final String src, final String queryString, final outputAttrs, final String endOfLine ->
 			if (endOfLine) {
-				outPw << '<link rel="stylesheet" href="' << src << '" ' << paramsToHtmlAttr(outputAttrs) << '/>' << endOfLine
+				outPw << '<link rel="stylesheet" href="' << assetPath(src: src) << queryString << '" ' << paramsToHtmlAttr(outputAttrs) << '/>' << endOfLine
 			}
 			else {
-				outPw << link([rel: 'stylesheet', href: src] + outputAttrs)
+				outPw << link([rel: 'stylesheet', href: src] + outputAttrs) << queryString
 			}
 		}
 	}
@@ -56,7 +56,7 @@ class AssetsTagLib {
 
 		final def nonBundledMode = (!grailsApplication.warDeployed && grailsApplication.config.grails.assets.bundle != true && attrs.remove('bundle') != 'true')
 		if (! nonBundledMode) {
-			output(assetPath(src: src), attrs, '')
+			output(src, '', attrs, '')
 		}
 		else {
 			final int lastDotIndex = src.lastIndexOf('.')
@@ -70,12 +70,12 @@ class AssetsTagLib {
 				uri       = src
 				extension = ext
 			}
-			final def modifierParams = ['compile=false']
-			if (attrs.charset) {
-				modifierParams << "encoding=${attrs.charset}"
-			}
+			final String queryString =
+				attrs.charset \
+					? "?compile=false&encoding=${attrs.charset}"
+					: '?compile=false'
 			AssetPipeline.getDependencyList(uri, contentType, extension).each {
-				output("${assetPath([src: "${it.path}", ignorePrefix: true])}?${modifierParams.join('&')}", attrs, LINE_BREAK)
+				output("${it.path}", queryString, attrs, LINE_BREAK)
 			}
 		}
 	}

--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -30,8 +30,10 @@ class AssetsTagLib {
 	}
 
 	/**
-	 * @attr href OPTIONAL alternative to src
-	 * @attr src OPTIONAL alternative to href
+	 * At least one of {@code href} and {@code src} must be supplied
+	 *
+	 * @attr href OPTIONAL standard URL attribute
+	 * @attr src  OPTIONAL alternate URL attribute, only used if {@code href} isn't supplied, or if {@code href} is Groovy false
 	 */
 	def stylesheet = {final attrs ->
 		final GrailsPrintWriter outPw = out

--- a/scripts/_AssetCompile.groovy
+++ b/scripts/_AssetCompile.groovy
@@ -28,13 +28,14 @@ target(assetCompile: "Precompiles assets in the application as specified by the 
 
 	event("AssetPrecompileStart", [assetConfig])
 
-	assetConfig.minifyJs         = config.grails.assets.containsKey('minifyJs')  ? config.grails.assets.minifyJs  : (argsMap.containsKey('minifyJs')  ? argsMap.minifyJs  == 'true' : true)
-	assetConfig.minifyCss        = config.grails.assets.containsKey('minifyCss') ? config.grails.assets.minifyCss : (argsMap.containsKey('minifyCss') ? argsMap.minifyCss == 'true' : true)
+	assetConfig.minifyJs         = config.grails.assets.containsKey('minifyJs')         ? config.grails.assets.minifyJs  : (argsMap.containsKey('minifyJs')  ? argsMap.minifyJs  == 'true' : true)
+	assetConfig.minifyCss        = config.grails.assets.containsKey('minifyCss')        ? config.grails.assets.minifyCss : (argsMap.containsKey('minifyCss') ? argsMap.minifyCss == 'true' : true)
 	assetConfig.minifyOptions    = config.grails.assets.minifyOptions
 	assetConfig.compileDir       = "${basedir}/target/assets"
 	assetConfig.excludesGzip     = config.grails.assets.excludesGzip
 	assetConfig.enableSourceMaps = config.grails.assets.containsKey('enableSourceMaps') ? config.grails.assets.enableSourceMaps : true
 	assetConfig.skipNonDigests   = config.grails.assets.containsKey('skipNonDigests')   ? config.grails.assets.skipNonDigests   : true
+	assetConfig.enableDigests    = config.grails.assets.containsKey('enableDigests')    ? config.grails.assets.enableDigests    : true
 
 	//Add Resolvers for Grails
 	assetPipelineConfigHolder.registerResolver(fileSystemAssetResolver.newInstance('application',"${basedir}/grails-app/assets"))

--- a/src/docs/guide/configuration.gdoc
+++ b/src/docs/guide/configuration.gdoc
@@ -28,7 +28,7 @@ grails.assets.skipNonDigests | *true* or *false* | *true*
 
 
 {note}
-It is not necessary for you to normally turn off 'skipNonDigests'. Tomcat will automatically still serve files by non digest name and will copy them out using storagePath via the `manifest.properties` alias map.
+It is normally not necessary to turn off 'skipNonDigests'. Tomcat will automatically still serve files by non digest name and will copy them out using storagePath via the `manifest.properties` alias map.
 This simply cuts storage in half. However, if you are attempting to do things like upload to a cdn outside of the cdn-asset-pipeline plugin and via the contents of 'target/assets'. This may still be useful.
 {note}
 

--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -15,6 +15,7 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	}
 
 
+	@Override
 	String resource(final Map attrs) {
 		asset(attrs) ?: super.resource(attrs)
 	}
@@ -25,5 +26,10 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	 */
 	String asset(final Map attrs) {
 		assetProcessorService.asset(attrs, this)
+	}
+
+	@Override
+	String makeServerURL() {
+		assetProcessorService.makeServerURL(this)
 	}
 }

--- a/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/LinkGenerator.groovy
@@ -16,6 +16,7 @@ class LinkGenerator extends DefaultLinkGenerator {
 	}
 
 
+	@Override
 	String resource(final Map attrs) {
 		asset(attrs) ?: super.resource(attrs)
 	}
@@ -26,5 +27,10 @@ class LinkGenerator extends DefaultLinkGenerator {
 	 */
 	String asset(final Map attrs) {
 		assetProcessorService.asset(attrs, this)
+	}
+
+	@Override
+	String makeServerURL() {
+		assetProcessorService.makeServerURL(this)
 	}
 }

--- a/src/java/asset/pipeline/grails/utils/net/HttpServletRequests.java
+++ b/src/java/asset/pipeline/grails/utils/net/HttpServletRequests.java
@@ -1,0 +1,200 @@
+package asset.pipeline.grails.utils.net;
+
+
+import javax.servlet.http.HttpServletRequest;
+
+import static asset.pipeline.utils.net.Urls.getDefaultPort;
+import static asset.pipeline.utils.net.Urls.hasAuthority;
+import static org.codehaus.groovy.grails.web.util.WebUtils.getForwardURI;
+
+
+/**
+ * @author Ross Goldberg
+ */
+public final class HttpServletRequests {
+
+	public static String getScheme(final HttpServletRequest req) {
+		final String forwardedScheme = req.getHeader("x-forwarded-proto");
+		return
+			forwardedScheme == null
+				? req.getScheme()
+				: forwardedScheme
+		;
+	}
+
+
+	public static int getPort(final HttpServletRequest req) {
+		final String forwardedPort = req.getHeader("x-forwarded-port");
+		return
+			forwardedPort == null
+				? req.getServerPort()
+				: Integer.parseInt(forwardedPort)
+		;
+	}
+
+
+	public static StringBuilder getAuthorityUrl(final HttpServletRequest req, final Object o) {
+		return
+			o == null
+				? getAuthorityUrlWithScheme(req)
+				: o instanceof Boolean
+					? getAuthorityUrl(req, ((Boolean) o).booleanValue())
+					: getAuthorityUrlWithScheme(req, o.toString())
+		;
+	}
+
+	public static StringBuilder getAuthorityUrl(final HttpServletRequest req, final boolean retainScheme) {
+		return
+			retainScheme
+				? getAuthorityUrlWithScheme(req)
+				: getAuthorityUrlSansScheme(req)
+		;
+	}
+
+	public static StringBuilder getAuthorityUrlWithScheme(final HttpServletRequest req) {
+		return getAuthorityUrlWithScheme(req, getScheme(req), true);
+	}
+
+	public static StringBuilder getAuthorityUrlWithScheme(final HttpServletRequest req, final String scheme) {
+		return getAuthorityUrlWithScheme(req, scheme, getScheme(req).equals(scheme));
+	}
+
+	public static StringBuilder getAuthorityUrlWithScheme(final HttpServletRequest req, final String scheme, final boolean includeNonDefaultPort) {
+		return getAuthorityUrlSansScheme(req, includeNonDefaultPort, new StringBuilder().append(scheme).append(':'));
+	}
+
+	public static StringBuilder getAuthorityUrlSansScheme(final HttpServletRequest req) {
+		return getAuthorityUrlSansScheme(req, false);
+	}
+
+	public static StringBuilder getAuthorityUrlSansScheme(final HttpServletRequest req, final String schemeToIncludeNonDefaultPort) {
+		return getAuthorityUrlSansScheme(req, getScheme(req).equals(schemeToIncludeNonDefaultPort));
+	}
+
+	public static StringBuilder getAuthorityUrlSansScheme(final HttpServletRequest req, final boolean includeNonDefaultPort) {
+		return getAuthorityUrlSansScheme(req, includeNonDefaultPort, new StringBuilder());
+	}
+
+	private static StringBuilder getAuthorityUrlSansScheme(final HttpServletRequest req, final boolean includeNonDefaultPort, final StringBuilder urlSb) {
+		urlSb.append("//").append(req.getServerName());
+
+		if (includeNonDefaultPort) {
+			final int port = getPort(req);
+
+			if (
+				port >= 0 &&
+				port != getDefaultPort(getScheme(req))
+			) {
+				urlSb.append(':').append(port);
+			}
+		}
+
+		return urlSb;
+	}
+
+
+	public static StringBuilder getBaseUrl(final HttpServletRequest req, final Object o) {
+		return
+			o == null
+				? getBaseUrlWithScheme(req)
+				: o instanceof Boolean
+					? getBaseUrl(req, ((Boolean) o).booleanValue())
+					: getBaseUrlWithScheme(req, o.toString())
+		;
+	}
+
+	public static StringBuilder getBaseUrl(final HttpServletRequest req, final boolean retainScheme) {
+		return
+			retainScheme
+				? getBaseUrlWithScheme(req)
+				: getBaseUrlSansScheme(req)
+		;
+	}
+
+	public static StringBuilder getBaseUrlWithScheme(final HttpServletRequest req) {
+		return getBaseUrlWithScheme(req, getScheme(req), true);
+	}
+
+	public static StringBuilder getBaseUrlWithScheme(final HttpServletRequest req, final String scheme) {
+		return getBaseUrlWithScheme(req, scheme, getScheme(req).equals(scheme));
+	}
+
+	public static StringBuilder getBaseUrlWithScheme(final HttpServletRequest req, final String scheme, final boolean includeNonDefaultPort) {
+		return getBaseUrlSansScheme(req, includeNonDefaultPort, new StringBuilder().append(scheme).append(':'));
+	}
+
+	public static StringBuilder getBaseUrlSansScheme(final HttpServletRequest req) {
+		return getBaseUrlSansScheme(req, false);
+	}
+
+	public static StringBuilder getBaseUrlSansScheme(final HttpServletRequest req, final String schemeToIncludeNonDefaultPort) {
+		return getBaseUrlSansScheme(req, getScheme(req).equals(schemeToIncludeNonDefaultPort));
+	}
+
+	public static StringBuilder getBaseUrlSansScheme(final HttpServletRequest req, final boolean includeNonDefaultPort) {
+		return getBaseUrlSansScheme(req, includeNonDefaultPort, new StringBuilder());
+	}
+
+	private static StringBuilder getBaseUrlSansScheme(final HttpServletRequest req, final boolean includeNonDefaultPort, final StringBuilder urlSb) {
+		return getAuthorityUrlSansScheme(req, includeNonDefaultPort, urlSb).append(req.getContextPath());
+	}
+
+
+	public static String prependBaseUrlWithScheme(final HttpServletRequest req, final String url) {
+		return
+			hasAuthority(url)
+				? url
+				: getBaseUrlWithScheme(req).append(url).toString()
+		;
+	}
+
+
+	public static StringBuilder getForwardUrl(final HttpServletRequest req, final Object o) {
+		return
+			o == null
+				? getForwardUrlWithScheme(req)
+				: o instanceof Boolean
+					? getForwardUrl(req, ((Boolean) o).booleanValue())
+					: getForwardUrlWithScheme(req, o.toString())
+		;
+	}
+
+	public static StringBuilder getForwardUrl(final HttpServletRequest req, final boolean retainScheme) {
+		return
+			retainScheme
+				? getForwardUrlWithScheme(req)
+				: getForwardUrlSansScheme(req)
+		;
+	}
+
+	public static StringBuilder getForwardUrlWithScheme(final HttpServletRequest req) {
+		return getForwardUrlWithScheme(req, getScheme(req), true);
+	}
+
+	public static StringBuilder getForwardUrlWithScheme(final HttpServletRequest req, final String scheme) {
+		return getForwardUrlWithScheme(req, scheme, getScheme(req).equals(scheme));
+	}
+
+	public static StringBuilder getForwardUrlWithScheme(final HttpServletRequest req, final String scheme, final boolean includeNonDefaultPort) {
+		return getForwardUrlSansScheme(req, includeNonDefaultPort, new StringBuilder().append(scheme).append(':'));
+	}
+
+	public static StringBuilder getForwardUrlSansScheme(final HttpServletRequest req) {
+		return getForwardUrlSansScheme(req, false);
+	}
+
+	public static StringBuilder getForwardUrlSansScheme(final HttpServletRequest req, final String schemeToIncludeNonDefaultPort) {
+		return getForwardUrlSansScheme(req, getScheme(req).equals(schemeToIncludeNonDefaultPort));
+	}
+
+	public static StringBuilder getForwardUrlSansScheme(final HttpServletRequest req, final boolean includeNonDefaultPort) {
+		return getForwardUrlSansScheme(req, includeNonDefaultPort, new StringBuilder());
+	}
+
+	private static StringBuilder getForwardUrlSansScheme(final HttpServletRequest req, final boolean includeNonDefaultPort, final StringBuilder urlSb) {
+		return getAuthorityUrlSansScheme(req, includeNonDefaultPort, urlSb).append(getForwardURI(req));
+	}
+
+
+	private HttpServletRequests() {}
+}

--- a/src/java/asset/pipeline/grails/utils/text/StringBuilders.java
+++ b/src/java/asset/pipeline/grails/utils/text/StringBuilders.java
@@ -1,0 +1,42 @@
+package asset.pipeline.grails.utils.text;
+
+
+/**
+ * @author Ross Goldberg
+ */
+public final class StringBuilders {
+
+    public static StringBuilder ensureEndsWith(final StringBuilder sb, final char suffix) {
+        final int len = sb.length();
+        return
+            len != 0 && sb.charAt(len - 1) == suffix
+                ? sb
+                : sb.append(suffix)
+        ;
+    }
+
+
+    public static StringBuilder from(final Object o) {
+        final String s;
+        return
+            o instanceof CharSequence
+                ? from((CharSequence) o)
+                : o == null
+                    ? null
+                    : new StringBuilder((s = o.toString()).length() * 2).append(s)
+        ;
+    }
+
+    public static StringBuilder from(final CharSequence cs) {
+        return
+            cs instanceof StringBuilder
+                ? (StringBuilder) cs
+                : cs == null
+                    ? null
+                    : new StringBuilder(cs.length() * 2).append(cs)
+        ;
+    }
+
+
+    private StringBuilders() {}
+}

--- a/test/integration/asset/pipeline/grails/CachingLinkGeneratorSpec.groovy
+++ b/test/integration/asset/pipeline/grails/CachingLinkGeneratorSpec.groovy
@@ -25,7 +25,6 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
 
     def "finds assets when calling for resource in dev mode"() {
         given: "A LinkGenerator and an image"
-            grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
 
@@ -38,7 +37,6 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
 
     def "finds assets with absolute path when calling for resource in dev mode"() {
         given: "A LinkGenerator and an image"
-            grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
 
@@ -52,7 +50,6 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
 
     def "finds asset in precompiled (prod) mode"() {
         given: "A LinkGenerator and an image"
-            grailsApplication.config.grails.assets.precompiled = true
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
             def filePath = "grails_logo.png"
@@ -68,7 +65,6 @@ class CachingLinkGeneratorSpec extends IntegrationSpec {
 
     def "falls back to standard resource lookup if not found in asset pipeline"() {
         given: "A LinkGenerator and an image"
-            grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new CachingLinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
 

--- a/test/integration/asset/pipeline/grails/LinkGeneratorSpec.groovy
+++ b/test/integration/asset/pipeline/grails/LinkGeneratorSpec.groovy
@@ -26,7 +26,6 @@ class LinkGeneratorSpec extends IntegrationSpec {
     def "finds assets when calling for resource in dev mode"() {
         given: "A LinkGenerator and an image"
             AssetPipelineConfigHolder.manifest = null
-            grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new LinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
 
@@ -41,7 +40,6 @@ class LinkGeneratorSpec extends IntegrationSpec {
     def "finds assets with absolute path when calling for resource in dev mode"() {
         given: "A LinkGenerator and an image"
             AssetPipelineConfigHolder.manifest = null
-            grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new LinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
 
@@ -54,7 +52,6 @@ class LinkGeneratorSpec extends IntegrationSpec {
 
     def "finds asset in precompiled (prod) mode"() {
         given: "A LinkGenerator and an image"
-            grailsApplication.config.grails.assets.precompiled = true
             def linkGenerator = new LinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
             def filePath = "grails_logo.png"
@@ -71,7 +68,6 @@ class LinkGeneratorSpec extends IntegrationSpec {
 
     def "falls back to standard resource lookup if not found in asset pipeline"() {
         given: "A LinkGenerator and an image"
-            grailsApplication.config.grails.assets.precompiled = false
             def linkGenerator = new LinkGenerator("http://localhost:8080")
             linkGenerator.assetProcessorService = assetProcessorService
 

--- a/test/unit/asset/pipeline/grails/AssetMethodTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetMethodTagLibSpec.groovy
@@ -13,33 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package asset.pipeline.grails
 
-import grails.test.mixin.TestFor
-import spock.lang.Specification
+
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.fs.FileSystemAssetResolver
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
 
 /**
  * @author David Estes
  */
 @TestFor(AssetMethodTagLib)
 class AssetMethodTagLibSpec extends Specification {
-  AssetProcessorService assetProcessorService = new AssetProcessorService()
 
-  def setup() {
-    AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('application','grails-app/assets'))
+	private static final MOCK_BASE_SERVER_URL = 'http://localhost:8080/foo'
 
-    assetProcessorService.grailsApplication = grailsApplication
 
-    tagLib.assetProcessorService = assetProcessorService
-  }
+	AssetProcessorService assetProcessorService = new AssetProcessorService()
 
-  void "should return assetPath"() {
-    given:
-      def assetSrc = "asset-pipeline/test/test.css"
-    expect:
-      tagLib.assetPath(src: assetSrc) == '/assets/asset-pipeline/test/test.css'
-  }
+
+	def setup() {
+		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('application','grails-app/assets'))
+
+		assetProcessorService.grailsApplication   = grailsApplication
+		assetProcessorService.grailsLinkGenerator = [serverBaseURL: MOCK_BASE_SERVER_URL]
+
+		tagLib.assetProcessorService = assetProcessorService
+	}
+
+	void "should return assetPath"() {
+		given:
+          final def assetSrc = "asset-pipeline/test/test.css"
+		expect:
+			tagLib.assetPath(src: assetSrc) == '/assets/asset-pipeline/test/test.css'
+	}
 }

--- a/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -142,7 +142,6 @@ class AssetsTagLibSpec extends Specification {
   void "test if asset path exists in dev mode"() {
     given:
       def fileUri = "asset-pipeline/test/test.css"
-      grailsApplication.config.grails.assets.precompiled = false
     expect:
       tagLib.assetPathExists([src: fileUri])
   }
@@ -150,7 +149,6 @@ class AssetsTagLibSpec extends Specification {
   void "test if asset path is missing in dev mode"() {
     given:
       def fileUri = "asset-pipeline/test/missing.css"
-      grailsApplication.config.grails.assets.precompiled = false
     expect:
       !tagLib.assetPathExists([src: fileUri])
   }
@@ -158,7 +156,6 @@ class AssetsTagLibSpec extends Specification {
   void "test if asset path exists in dev mode and closure renders the body"() {
     given:
       def fileUri = "asset-pipeline/test/test.css"
-      grailsApplication.config.grails.assets.precompiled = false
     expect:
       applyTemplate( "<asset:assetPathExists src=\"$fileUri\">text to render</asset:assetPathExists>" ) == 'text to render'
   }
@@ -166,7 +163,6 @@ class AssetsTagLibSpec extends Specification {
   void "test if asset path is missing in dev mode and closure doesn't render the body"() {
     given:
       def fileUri = "asset-pipeline/test/missing.css"
-      grailsApplication.config.grails.assets.precompiled = false
     expect:
       applyTemplate( "<asset:assetPathExists src=\"$fileUri\">text to render</asset:assetPathExists>" ) == ''
   }
@@ -177,7 +173,6 @@ class AssetsTagLibSpec extends Specification {
       Properties manifestProperties = new Properties()
       manifestProperties.setProperty(fileUri,fileUri)
 
-      grailsApplication.config.grails.assets.precompiled = true
       grailsApplication.config.grails.assets.manifest = manifestProperties
     expect:
       tagLib.assetPathExists([src: fileUri])
@@ -186,7 +181,6 @@ class AssetsTagLibSpec extends Specification {
   void "asset path should not exist in dev mode"() {
     given:
       def fileUri = "asset-pipeline/test/notfound.css"
-      grailsApplication.config.grails.assets.precompiled = false
     expect:
       !tagLib.assetPathExists([src: fileUri])
   }

--- a/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/test/unit/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -13,196 +13,194 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package asset.pipeline.grails
 
+
+import asset.pipeline.AssetPipelineConfigHolder
+import asset.pipeline.fs.FileSystemAssetResolver
 import grails.test.mixin.TestFor
 import spock.lang.Specification
-import asset.pipeline.AssetPipelineConfigHolder
+
 
 /**
  * @author David Estes
  */
 @TestFor(AssetsTagLib)
 class AssetsTagLibSpec extends Specification {
-  AssetProcessorService assetProcessorService = new AssetProcessorService()
-  private static final LINE_BREAK = System.getProperty('line.separator') ?: '\n'
-  private static MOCK_BASE_SERVER_URL = 'http://localhost:8080/foo'
 
-  def setup() {
-    AssetPipelineConfigHolder.registerResolver(new asset.pipeline.fs.FileSystemAssetResolver('application','grails-app/assets'))
+	private static final LINE_BREAK           = System.getProperty('line.separator') ?: '\n'
+	private static final MOCK_BASE_SERVER_URL = 'http://localhost:8080/foo'
 
-    assetProcessorService.grailsApplication = grailsApplication
 
-    def assetMethodTagLibMock = mockTagLib(AssetMethodTagLib)
-    assetMethodTagLibMock.assetProcessorService = assetProcessorService
-    assetMethodTagLibMock.grailsLinkGenerator   = [serverBaseURL: MOCK_BASE_SERVER_URL]
+	AssetProcessorService assetProcessorService = new AssetProcessorService()
 
-    tagLib.assetProcessorService = assetProcessorService
-  }
 
-  void "should return assetPath"() {
-    given:
-      def assetSrc = "asset-pipeline/test/test.css"
-    expect:
-      tagLib.assetPath(src: assetSrc) == '/assets/asset-pipeline/test/test.css'
-  }
+	def setup() {
+		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('application', 'grails-app/assets'))
 
-  void "should return javascript link tag when debugMode is off"() {
-    given:
-      grailsApplication.config.grails.assets.bundle = true
-      def assetSrc = "asset-pipeline/test/test.js"
-    expect:
-      tagLib.javascript(src: assetSrc) == '<script src="/assets/asset-pipeline/test/test.js" type="text/javascript" ></script>'
-  }
+		assetProcessorService.grailsApplication   = grailsApplication
+		assetProcessorService.grailsLinkGenerator = [serverBaseURL: MOCK_BASE_SERVER_URL]
 
-  void "should always return javascript link tag when bundle attr is 'true'"() {
-    given:
-      grailsApplication.config.grails.assets.bundle = false
-      grailsApplication.config.grails.assets.allowDebugParam = true
-      params."_debugAssets" = "y"
-      def assetSrc = "asset-pipeline/test/test.js"
-    expect:
-      tagLib.javascript(src: assetSrc, bundle: 'true') == '<script src="/assets/asset-pipeline/test/test.js" type="text/javascript" ></script>'
-  }
+		final def assetMethodTagLibMock = mockTagLib(AssetMethodTagLib)
+		assetMethodTagLibMock.assetProcessorService = assetProcessorService
 
-  void "should return javascript link tag with seperated files when debugMode is on"() {
-    given:
-      grailsApplication.config.grails.assets.bundle = false
-      grailsApplication.config.grails.assets.allowDebugParam = true
-      params."_debugAssets" = "y"
-      def stringWriter = new StringWriter()
+		tagLib.assetProcessorService = assetProcessorService
+	}
 
-      def assetSrc = "asset-pipeline/test/test.js"
-      def output
-    when:
-      // tagLib.out = stringWriter
-      output = tagLib.javascript(src: assetSrc)
+	void "should return assetPath"() {
+		given:
+			final def assetSrc = "asset-pipeline/test/test.css"
+		expect:
+			tagLib.assetPath(src: assetSrc) == '/assets/asset-pipeline/test/test.css'
+	}
 
-    then:
-      output == '<script src="/assets/asset-pipeline/test/test.js?compile=false" type="text/javascript" ></script>' + LINE_BREAK + '<script src="/assets/asset-pipeline/test/libs/file_a.js?compile=false" type="text/javascript" ></script>' + LINE_BREAK + '<script src="/assets/asset-pipeline/test/libs/file_c.js?compile=false" type="text/javascript" ></script>' + LINE_BREAK + '<script src="/assets/asset-pipeline/test/libs/file_b.js?compile=false" type="text/javascript" ></script>' + LINE_BREAK + '<script src="/assets/asset-pipeline/test/libs/subset/subset_a.js?compile=false" type="text/javascript" ></script>' + LINE_BREAK
-  }
+	void "should return javascript link tag when debugMode is off"() {
+		given:
+			grailsApplication.config.grails.assets.bundle = true
+			final def assetSrc = "asset-pipeline/test/test.js"
+		expect:
+			tagLib.javascript(src: assetSrc) == '<script type="text/javascript" src="/assets/asset-pipeline/test/test.js" ></script>'
+	}
 
-  void "should return stylesheet link tag when debugMode is off"() {
-    given:
-      grailsApplication.config.grails.assets.bundle = true
-      def assetSrc = "asset-pipeline/test/test.css"
-    expect:
-      tagLib.stylesheet(href: assetSrc) == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css"/>'
-  }
+	void "should always return javascript link tag when bundle attr is 'true'"() {
+		given:
+			grailsApplication.config.grails.assets.bundle = false
+			grailsApplication.config.grails.assets.allowDebugParam = true
+			params."_debugAssets" = "y"
+			final def assetSrc = "asset-pipeline/test/test.js"
+		expect:
+			tagLib.javascript(src: assetSrc, bundle: 'true') == '<script type="text/javascript" src="/assets/asset-pipeline/test/test.js" ></script>'
+	}
 
-  void "should always return stylesheet link tag when bundle attr is 'true'"() {
-    given:
-      grailsApplication.config.grails.assets.bundle = false
-      grailsApplication.config.grails.assets.allowDebugParam = true
-      params."_debugAssets" = "y"
-      def assetSrc = "asset-pipeline/test/test.css"
-    expect:
-      tagLib.stylesheet(href: assetSrc, bundle: 'true') == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css"/>'
-  }
+	void "should return javascript link tag with seperated files when debugMode is on"() {
+		given:
+			grailsApplication.config.grails.assets.bundle = false
+			grailsApplication.config.grails.assets.allowDebugParam = true
+			params."_debugAssets" = "y"
 
-  void "should return stylesheet link tag with seperated files when debugMode is on"() {
-    given:
-      grailsApplication.config.grails.assets.bundle = false
-      grailsApplication.config.grails.assets.allowDebugParam = true
-      params."_debugAssets" = "y"
-      def stringWriter = new StringWriter()
+			final def assetSrc = "asset-pipeline/test/test.js"
+			final def output
 
-      def assetSrc = "asset-pipeline/test/test.css"
-      def output
-    when:
-      // tagLib.out = stringWriter
-      output = tagLib.stylesheet(src: assetSrc)
-    then:
-      output == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css?compile=false" />' + LINE_BREAK + '<link rel="stylesheet" href="/assets/asset-pipeline/test/test2.css?compile=false" />' + LINE_BREAK
-  }
+		when:
+			output = tagLib.javascript(src: assetSrc)
+		then:
+			output == '<script type="text/javascript" src="/assets/asset-pipeline/test/test.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/file_a.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/file_c.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/file_b.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/subset/subset_a.js?compile=false" ></script>' + LINE_BREAK
+	}
 
-  void "should return image tag"() {
-    given:
-      def assetSrc = "grails_logo.png"
-    expect:
-      tagLib.image(src: assetSrc, width:'200',height:200) == '<img src="/assets/grails_logo.png" width="200" height="200"/>'
-  }
+	void "should return stylesheet link tag when debugMode is off"() {
+		given:
+			grailsApplication.config.grails.assets.bundle = true
+			final def assetSrc = "asset-pipeline/test/test.css"
+		expect:
+			tagLib.stylesheet(href: assetSrc) == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css"/>'
+	}
 
-  void "should return image tag with absolute path"() {
-    given:
-      def assetSrc = "grails_logo.png"
+	void "should always return stylesheet link tag when bundle attr is 'true'"() {
+		given:
+			grailsApplication.config.grails.assets.bundle = false
+			grailsApplication.config.grails.assets.allowDebugParam = true
+			params."_debugAssets" = "y"
+			final def assetSrc = "asset-pipeline/test/test.css"
+		expect:
+			tagLib.stylesheet(href: assetSrc, bundle: 'true') == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css"/>'
+	}
 
-    expect:
-      tagLib.image(src: assetSrc, absolute: true) == "<img src=\"$MOCK_BASE_SERVER_URL/assets/grails_logo.png\" />"
-  }
+	void "should return stylesheet link tag with seperated files when debugMode is on"() {
+		given:
+			grailsApplication.config.grails.assets.bundle = false
+			grailsApplication.config.grails.assets.allowDebugParam = true
+			params."_debugAssets" = "y"
+			final def assetSrc = "asset-pipeline/test/test.css"
+			final def output
 
-  void "should return link tag"() {
-    given:
-      def assetSrc = "grails_logo.png"
-    expect:
-      tagLib.link(href: assetSrc, rel:'test') == '<link rel="test" href="/assets/grails_logo.png"/>'
-  }
+		when:
+			output = tagLib.stylesheet(src: assetSrc)
+		then:
+			output == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css?compile=false" />' + LINE_BREAK + '<link rel="stylesheet" href="/assets/asset-pipeline/test/test2.css?compile=false" />' + LINE_BREAK
+	}
 
-  void "test if asset path exists in dev mode"() {
-    given:
-      def fileUri = "asset-pipeline/test/test.css"
-    expect:
-      tagLib.assetPathExists([src: fileUri])
-  }
+	void "should return image tag"() {
+		given:
+			final def assetSrc = "grails_logo.png"
+		expect:
+			tagLib.image(src: assetSrc, width:'200',height:200) == '<img src="/assets/grails_logo.png" width="200" height="200"/>'
+	}
 
-  void "test if asset path is missing in dev mode"() {
-    given:
-      def fileUri = "asset-pipeline/test/missing.css"
-    expect:
-      !tagLib.assetPathExists([src: fileUri])
-  }
+	void "should return image tag with absolute path"() {
+		given:
+			final def assetSrc = "grails_logo.png"
+		expect:
+			tagLib.image(src: assetSrc, absolute: true) == "<img src=\"$MOCK_BASE_SERVER_URL/assets/grails_logo.png\" />"
+	}
 
-  void "test if asset path exists in dev mode and closure renders the body"() {
-    given:
-      def fileUri = "asset-pipeline/test/test.css"
-    expect:
-      applyTemplate( "<asset:assetPathExists src=\"$fileUri\">text to render</asset:assetPathExists>" ) == 'text to render'
-  }
+	void "should return link tag"() {
+		given:
+			final def assetSrc = "grails_logo.png"
+		expect:
+			tagLib.link(href: assetSrc, rel:'test') == '<link rel="test" href="/assets/grails_logo.png"/>'
+	}
 
-  void "test if asset path is missing in dev mode and closure doesn't render the body"() {
-    given:
-      def fileUri = "asset-pipeline/test/missing.css"
-    expect:
-      applyTemplate( "<asset:assetPathExists src=\"$fileUri\">text to render</asset:assetPathExists>" ) == ''
-  }
+	void "test if asset path exists in dev mode"() {
+		given:
+			final def fileUri = "asset-pipeline/test/test.css"
+		expect:
+			tagLib.assetPathExists([src: fileUri])
+	}
 
-  void "test if asset path exists in prod mode"() {
-    given:
-      def fileUri = "asset-pipeline/test/test.css"
-      Properties manifestProperties = new Properties()
-      manifestProperties.setProperty(fileUri,fileUri)
+	void "test if asset path is missing in dev mode"() {
+		given:
+			final def fileUri = "asset-pipeline/test/missing.css"
+		expect:
+			!tagLib.assetPathExists([src: fileUri])
+	}
 
-      grailsApplication.config.grails.assets.manifest = manifestProperties
-    expect:
-      tagLib.assetPathExists([src: fileUri])
-  }
+	void "test if asset path exists in dev mode and closure renders the body"() {
+		given:
+			final def fileUri = "asset-pipeline/test/test.css"
+		expect:
+			applyTemplate( "<asset:assetPathExists src=\"$fileUri\">text to render</asset:assetPathExists>" ) == 'text to render'
+	}
 
-  void "asset path should not exist in dev mode"() {
-    given:
-      def fileUri = "asset-pipeline/test/notfound.css"
-    expect:
-      !tagLib.assetPathExists([src: fileUri])
-  }
+	void "test if asset path is missing in dev mode and closure doesn't render the body"() {
+		given:
+			final def fileUri = "asset-pipeline/test/missing.css"
+		expect:
+			applyTemplate( "<asset:assetPathExists src=\"$fileUri\">text to render</asset:assetPathExists>" ) == ''
+	}
 
-  void "should render deferred scripts"() {
-    given:
-      def script1 = "console.log('hello world 1');"
-      def script2 = "console.log('hello world 2');"
+	void "test if asset path exists in prod mode"() {
+		given:
+			final def fileUri = "asset-pipeline/test/test.css"
+			final Properties manifestProperties = new Properties()
+			manifestProperties.setProperty(fileUri,fileUri)
+			grailsApplication.config.grails.assets.manifest = manifestProperties
+		expect:
+			tagLib.assetPathExists([src: fileUri])
+	}
 
-    when:
-      applyTemplate("<asset:script type='text/javascript'>$script1</asset:script>")
-      applyTemplate("<asset:script type='text/javascript'>$script2</asset:script>")
+	void "asset path should not exist in dev mode"() {
+		given:
+			final def fileUri = "asset-pipeline/test/notfound.css"
+		expect:
+			!tagLib.assetPathExists([src: fileUri])
+	}
 
-    then:
-      applyTemplate("<asset:deferredScripts/>") == "<script type=\"text/javascript\">${script1}</script><script type=\"text/javascript\">${script2}</script>"
-  }
+	void "should render deferred scripts"() {
+		given:
+			final def script1 = "console.log('hello world 1');"
+			final def script2 = "console.log('hello world 2');"
 
-  void "should render deferred scripts and evaluate nested groovy expressions"() {
-    when:
-      applyTemplate('<asset:script type="text/javascript"><g:if test="${isTrue}">alert("foo");</g:if></asset:script>', [isTrue: true])
+		when:
+			applyTemplate("<asset:script type='text/javascript'>$script1</asset:script>")
+			applyTemplate("<asset:script type='text/javascript'>$script2</asset:script>")
+		then:
+			applyTemplate("<asset:deferredScripts/>") == "<script type=\"text/javascript\">${script1}</script><script type=\"text/javascript\">${script2}</script>"
+	}
 
-    then:
-      applyTemplate("<asset:deferredScripts/>") == '<script type="text/javascript">alert("foo");</script>'
-  }
+	void "should render deferred scripts and evaluate nested groovy expressions"() {
+		when:
+			applyTemplate('<asset:script type="text/javascript"><g:if test="${isTrue}">alert("foo");</g:if></asset:script>', [isTrue: true])
+		then:
+			applyTemplate("<asset:deferredScripts/>") == '<script type="text/javascript">alert("foo");</script>'
+	}
 }


### PR DESCRIPTION
This pull request contains the changes listed below.  Some of the changes should possibly have config settings added to enable / disable them.

1. a single leading slash, `/`, in an asset name will be removed to treat `/path/to/asset.ext` & `path/to/asset.ext` as the same asset
1. combined duplicate / semi-duplicate code into common code:
 1. `AssetProcessorService#assetUriRootPath()` & `AssetMethodTagLib#assetUriRootPath(boolean)` combined into `AssetProcessorService#assetBaseUrl(...)`
 1. `AssetsTagLib#javascript` & `AssetsTagLib#stylesheet` were combined into `AssetsTagLib#element(...)`
1. `AssetProcessorService#asset(...)` now properly considers a URL "non-absolute" if it lacks an authority, instead of if the URL doesn't start with `"http"`:
 1.  `httpNotAbsolute` is "non-absolute", but was previously erroneously considered "absolute"
 1. `//a.com/b.ext` is "absolute", but was previously erroneously considered "non-absolute"
 1. this now supports other schemes such as `ftp`, `sftp`, etc.
1. both `CachingLinkGenerator#makeServerURL()` & `LinkGenerator#makeServerURL()` now call `AssetProcessorService#makeServerURL(DefaultLinkGenerator)` so that `CachingLinkGenerator#getServerBaseURL()` & `LinkGenerator#getServerBaseURL()` & other related methods now generate a base URL that heeds HTTP headers `x-forwared-proto` & `x-forwared-port`:
 1. this allows AP to generate correct URLs even if it is running behind a load balancer that terminates SSL on itself, so that the client communicates with the load balancer via https, but the load balancer communicates with Grails / AP via http
1. make AP generate URLs for assets that are referenced by tags from non-AP TagLibs:
 1.  the following TagLibs are currently supported:
    1. `ApplicationTagLib`
    1. `JqueryUiTagLib`
    1. `ResourceTagLib`
 1. to remove the newly added dependencies on the `jquery-ui` & `resources` plugins, we should probably use `Class.forName(String)` to load their TagLibs if they are in the class path, then use Grails reflection to check for the existence of the `LINK_WRITERS` static field in any TagLibs that are found
1. `AssetPipelineBootStrap` copy of assets to `storagePath` now heeds both `skipNonDigests` & `enableDigests`
1. AP now heeds `enableDigests`, so digests can be disabled instead of always being used. `manifest.properties` is still generated containing digested names for use with eTags; it's just that digests aren't used in asset file names or in asset URLs
 1. pass `enableDigests` to APC
1. minor code cleanup, e.g.:
 1. removed vestigial settings of now unused `precompiled`
 1. minor performance improvements
 1. renamed local variables
 1. use static imports
 1. improved JavaDocs
 1. improved GDocs
 1. added missing `@Override`
 1. etc.
1. added utility classes:
 1. `asset.pipeline.grails.utils.net.HttpServletRequests`
 1. `asset.pipeline.grails.utils.text.StringBuilders`
1. reorganized config files
1. added missing variable types
1. converted less precise variable types (e.g. `def`) to more precise types (e.g. `String`)
1. parentheses standardization
1. double quotes to single quotes where `String` literal instead of `GString`
1. whitespace cleanup
 1. leading spaces to tabs
 1. trim trailing whitespace
 1. removed extra empty lines
 1. added appropriate empty lines
 1. space standardization