### PR TITLE
CachingLinkGenerator: override makeKey(String, Map) to have separate cache keys for different x-forwarded-* HTTP headers

### DIFF
--- a/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
+++ b/src/groovy/asset/pipeline/grails/CachingLinkGenerator.groovy
@@ -2,6 +2,10 @@ package asset.pipeline.grails
 
 
 import groovy.util.logging.Slf4j
+import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
+
+import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
+import static org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest.lookup
 
 
 @Slf4j
@@ -31,5 +35,24 @@ class CachingLinkGenerator extends org.codehaus.groovy.grails.web.mapping.Cachin
 	@Override
 	String makeServerURL() {
 		assetProcessorService.makeServerURL(this)
+	}
+
+	@Override
+	protected String makeKey(final String prefix, final Map attrs) {
+		final StringBuilder sb = new StringBuilder()
+		sb.append(prefix)
+		if (configuredServerBaseURL == null && isAbsolute(attrs)) {
+			final Object base = attrs.base
+			if (base != null) {
+				sb.append(base)
+			} else {
+				final GrailsWebRequest req = lookup()
+				if (req != null) {
+					sb.append(getBaseUrlWithScheme(req.currentRequest).toString())
+				}
+			}
+		}
+		appendMapKey(sb, attrs)
+		sb.toString()
 	}
 }


### PR DESCRIPTION
`CachingLinkGenerator`: override `makeKey(String, Map)` to have separate cache keys for different `x-forwarded-*` HTTP headers.

Otherwise, will cache whichever scheme & port are first seen, regardless of future values of `x-forwarded-*` HTTP headers.

Note that PR #304 is a branch off of this branch, so this PR should be merged first.