### PR TITLE
AssetsTagLib#stylesheet: no longer unnecessarily append empty queryString

### DIFF
--- a/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -42,7 +42,7 @@ class AssetsTagLib {
 				outPw << '<link rel="stylesheet" href="' << assetPath(src: src) << queryString << '" ' << paramsToHtmlAttr(outputAttrs) << '/>' << endOfLine
 			}
 			else {
-				outPw << link([rel: 'stylesheet', href: src] + outputAttrs) << queryString
+				outPw << link([rel: 'stylesheet', href: src] + outputAttrs)
 			}
 		}
 	}


### PR DESCRIPTION
A simple one-line cleanup.