### PR TITLE
avoid MissingPropertyException in AssetPipelinePlugin

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -72,11 +72,7 @@ class AssetPipelinePlugin implements Plugin<Project> {
             def assetPipeline = project.extensions.getByType(AssetPipelineExtension)
             ProcessResources processResources
             DistributionContainer distributionContainer
-            try {
-                processResources = (ProcessResources) project.tasks.processResources
-            } catch(UnknownTaskException ex) {
-                //we dont care this is just to see if it exists
-            }
+            processResources = (ProcessResources) project.tasks.findByName('processResources')
             try {
                 distributionContainer = project.extensions.getByType(DistributionContainer)
             } catch(UnknownDomainObjectException ex) {


### PR DESCRIPTION
When using asset pipeline in a project that has no `processResources` tasks, the build fails with exception:

```
groovy.lang.MissingPropertyException: Could not find property 'processResources' on task set.
        at org.gradle.api.internal.AbstractDynamicObject.propertyMissingException(AbstractDynamicObject.java:43)
        at org.gradle.api.internal.AbstractDynamicObject.getProperty(AbstractDynamicObject.java:35)
        at org.gradle.api.internal.CompositeDynamicObject.getProperty(CompositeDynamicObject.java:97)
        at org.gradle.api.internal.tasks.DefaultTaskContainer_Decorated.getProperty(Unknown Source)
        at asset.pipeline.gradle.AssetPipelinePlugin$_apply_closure1.doCall(AssetPipelinePlugin.groovy:76)
        at org.gradle.listener.ClosureBackedMethodInvocationDispatch.dispatch(ClosureBackedMethodInvocationDispatch.java:40)
        at org.gradle.listener.ClosureBackedMethodInvocationDispatch.dispatch(ClosureBackedMethodInvocationDispatch.java:25)
        at org.gradle.internal.event.AbstractBroadcastDispatch.dispatch(AbstractBroadcastDispatch.java:44)
        at org.gradle.internal.event.BroadcastDispatch.dispatch(BroadcastDispatch.java:79)
        at org.gradle.internal.event.BroadcastDispatch.dispatch(BroadcastDispatch.java:30)
        at org.gradle.messaging.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
        at com.sun.proxy.$Proxy12.afterEvaluate(Unknown Source)
        at org.gradle.configuration.project.LifecycleProjectEvaluator.notifyAfterEvaluate(LifecycleProjectEvaluator.java:67)
        ... 44 more
```

This fix uses `findByName` to find the task which simply returns `null` if the task is not found.

Environment:
* Gradle 2.13
* Asset Pipeline 2.8.2