### PR TITLE
Service to core

### DIFF
--- a/asset-pipeline-core/src/main/java/asset/pipeline/AssetPaths.java
+++ b/asset-pipeline-core/src/main/java/asset/pipeline/AssetPaths.java
@@ -1,0 +1,47 @@
+package asset.pipeline;
+
+
+import static asset.pipeline.AssetPipelineConfigHolder.manifest;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+
+/**
+ * @author Ross Goldberg
+ */
+public final class AssetPaths {
+
+	public static String getAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path);
+		if(manifest == null) {
+			return relativePath;
+		}
+		final String manifestPath = manifest.getProperty(relativePath);
+		return isNullOrEmpty(manifestPath) ? relativePath : manifestPath;
+	}
+
+
+	public static String getResolvedAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path);
+		if(manifest == null) {
+			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null;
+		}
+		return manifest.getProperty(relativePath);
+	}
+
+
+	public static boolean isAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path);
+		return !isNullOrEmpty(relativePath) && (manifest == null ? AssetHelper.fileForFullName(relativePath) != null : !isNullOrEmpty(manifest.getProperty(relativePath)));
+	}
+
+
+	private static String trimLeadingSlash(final String s) {
+		if(isNullOrEmpty(s) || s.charAt(0) != '/') {
+			return s;
+		}
+		return s.substring(1);
+	}
+
+
+	private AssetPaths() {}
+}

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -53,7 +53,7 @@ class AssetProcessorService {
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			return relativePath ? manifest.getProperty(relativePath) : null
+			return manifest.getProperty(relativePath)
 		} else {
 			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -1,11 +1,12 @@
 package asset.pipeline.grails
 
+
+import asset.pipeline.AssetHelper
+import grails.util.Environment
 import javax.servlet.http.HttpServletRequest
 import org.grails.web.mapping.DefaultLinkGenerator
 import org.grails.web.servlet.mvc.GrailsWebRequest
-import grails.util.Environment
 
-import asset.pipeline.AssetHelper
 import static asset.pipeline.AssetPipelineConfigHolder.manifest
 import static asset.pipeline.grails.UrlBase.*
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
@@ -57,7 +58,7 @@ class AssetProcessorService {
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
-		
+
 	}
 
 

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -47,7 +47,7 @@ class AssetProcessorService {
 
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath,relativePath) ?: relativePath
+		return manifest?.getProperty(relativePath, relativePath) ?: relativePath
 	}
 
 
@@ -58,7 +58,6 @@ class AssetProcessorService {
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
-
 	}
 
 
@@ -119,9 +118,10 @@ class AssetProcessorService {
 		}
 
 		def finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
-				.append(mapping)
-				.append('/' as char)
-				.toString()
+			.append(mapping)
+			.append('/' as char)
+			.toString()
+
 		return finalUrl
 	}
 

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -20,6 +20,7 @@ class AssetProcessorService {
 	static transactional = false
 
 
+	// <editor-fold desc="Grails-specific methods">
 	/**
 	 * Retrieves the asset path from the property [grails.assets.mapping] which is used by the url mapping and the
 	 * taglib.  The property cannot contain <code>/</code>, and must be one level deep
@@ -36,28 +37,6 @@ class AssetProcessorService {
 			)
 		}
 		return mapping
-	}
-
-
-	String getAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath) ?: relativePath
-	}
-
-
-	String getResolvedAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		if(manifest) {
-			return manifest.getProperty(relativePath)
-		} else {
-			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
-		}
-	}
-
-
-	boolean isAssetPath(final String path) {
-		final String relativePath = trimLeadingSlash(path)
-		return relativePath && (manifest ? manifest.getProperty(relativePath) : AssetHelper.fileForFullName(relativePath) != null)
 	}
 
 
@@ -80,6 +59,44 @@ class AssetProcessorService {
 		}
 
 		return url
+	}
+
+
+	String makeServerURL(final DefaultLinkGenerator linkGenerator) {
+		String serverUrl = linkGenerator.configuredServerBaseURL
+		if (! serverUrl) {
+			final GrailsWebRequest req = lookup()
+			if (req) {
+				serverUrl = getBaseUrlWithScheme(req.currentRequest).toString()
+				if (!serverUrl && !Environment.isWarDeployed()) {
+					serverUrl = "http://localhost:${System.getProperty('server.port') ?: '8080'}${linkGenerator.contextPath ?: ''}"
+				}
+			}
+		}
+		return serverUrl
+	}
+	// </editor-fold>
+
+
+	String getAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path)
+		return manifest?.getProperty(relativePath) ?: relativePath
+	}
+
+
+	String getResolvedAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path)
+		if(manifest) {
+			return manifest.getProperty(relativePath)
+		} else {
+			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
+		}
+	}
+
+
+	boolean isAssetPath(final String path) {
+		final String relativePath = trimLeadingSlash(path)
+		return relativePath && (manifest ? manifest.getProperty(relativePath) : AssetHelper.fileForFullName(relativePath) != null)
 	}
 
 
@@ -106,21 +123,6 @@ class AssetProcessorService {
 			.toString()
 
 		return finalUrl
-	}
-
-
-	String makeServerURL(final DefaultLinkGenerator linkGenerator) {
-		String serverUrl = linkGenerator.configuredServerBaseURL
-		if (! serverUrl) {
-			final GrailsWebRequest req = lookup()
-			if (req) {
-				serverUrl = getBaseUrlWithScheme(req.currentRequest).toString()
-				if (!serverUrl && !Environment.isWarDeployed()) {
-					serverUrl = "http://localhost:${System.getProperty('server.port') ?: '8080'}${linkGenerator.contextPath ?: ''}"
-				}
-			}
-		}
-		return serverUrl
 	}
 
 

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -9,20 +9,15 @@ import org.grails.web.servlet.mvc.GrailsWebRequest
 
 import static asset.pipeline.AssetPipelineConfigHolder.getConfig
 import static asset.pipeline.AssetPipelineConfigHolder.manifest
-import static asset.pipeline.grails.UrlBase.*
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
 import static asset.pipeline.grails.utils.text.StringBuilders.ensureEndsWith
 import static asset.pipeline.utils.net.Urls.hasAuthority
-import static org.apache.commons.lang.StringUtils.trimToEmpty
 import static org.grails.web.servlet.mvc.GrailsWebRequest.lookup
 
 
 class AssetProcessorService {
 
 	static transactional = false
-
-
-	def grailsLinkGenerator
 
 
 	/**
@@ -73,7 +68,7 @@ class AssetProcessorService {
 			return null
 		}
 
-		url = assetBaseUrl(null, NONE) + url
+		url = assetBaseUrl(null, '') + url
 		if (! hasAuthority(url)) {
 			String absolutePath = linkGenerator.handleAbsolute(attrs)
 
@@ -97,26 +92,13 @@ class AssetProcessorService {
 	}
 
 
-	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase) {
+	String assetBaseUrl(final HttpServletRequest req, final String baseUrl) {
 		final String url = getConfigBaseUrl(req)
 		if (url) {
 			return url
 		}
 
 		final String mapping = assetMapping
-
-		final String baseUrl
-		switch (urlBase) {
-			case SERVER_BASE_URL:
-				baseUrl = grailsLinkGenerator.serverBaseURL ?: ''
-				break
-			case CONTEXT_PATH:
-				baseUrl = trimToEmpty(grailsLinkGenerator.contextPath)
-				break
-			case NONE:
-				baseUrl = ''
-				break
-		}
 
 		final String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
 			.append(mapping)

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest
 import org.grails.web.mapping.DefaultLinkGenerator
 import org.grails.web.servlet.mvc.GrailsWebRequest
 
+import static asset.pipeline.AssetPipelineConfigHolder.getConfig
 import static asset.pipeline.AssetPipelineConfigHolder.manifest
 import static asset.pipeline.grails.UrlBase.*
 import static asset.pipeline.grails.utils.net.HttpServletRequests.getBaseUrlWithScheme
@@ -21,7 +22,6 @@ class AssetProcessorService {
 	static transactional = false
 
 
-	def grailsApplication
 	def grailsLinkGenerator
 
 
@@ -33,7 +33,7 @@ class AssetProcessorService {
 	 * @throws IllegalArgumentException if the path contains <code>/</code>
 	 */
 	String getAssetMapping() {
-		final String mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
+		final String mapping = config.mapping ?: 'assets'
 		if (mapping.contains('/')) {
 			throw new IllegalArgumentException(
 				'The property [grails.assets.mapping] can only be one level deep.  ' +
@@ -44,13 +44,13 @@ class AssetProcessorService {
 	}
 
 
-	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+	String getAssetPath(final String path) {
 		final String relativePath = trimLeadingSlash(path)
 		return manifest?.getProperty(relativePath) ?: relativePath
 	}
 
 
-	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+	String getResolvedAssetPath(final String path) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
 			return manifest.getProperty(relativePath)
@@ -88,8 +88,8 @@ class AssetProcessorService {
 	}
 
 
-	String getConfigBaseUrl(final HttpServletRequest req, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		final def url = conf.url
+	String getConfigBaseUrl(final HttpServletRequest req) {
+		final def url = config.url
 		if(url instanceof Closure) {
 			return url(req)
 		}
@@ -97,8 +97,8 @@ class AssetProcessorService {
 	}
 
 
-	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase, final ConfigObject conf = grailsApplication.config.grails.assets) {
-		final String url = getConfigBaseUrl(req, conf)
+	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase) {
+		final String url = getConfigBaseUrl(req)
 		if (url) {
 			return url
 		}

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -44,17 +44,16 @@ class AssetProcessorService {
 	}
 
 
-
 	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath, relativePath) ?: relativePath
+		return manifest?.getProperty(relativePath) ?: relativePath
 	}
 
 
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			relativePath ? manifest?.getProperty(relativePath) : null
+			relativePath ? manifest.getProperty(relativePath) : null
 		} else {
 			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
@@ -88,6 +87,7 @@ class AssetProcessorService {
 		return url
 	}
 
+
 	String getConfigBaseUrl(final HttpServletRequest req, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final def url = conf.url
 		if(url instanceof Closure) {
@@ -95,6 +95,7 @@ class AssetProcessorService {
 		}
 		return url ?: null
 	}
+
 
 	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String url = getConfigBaseUrl(req, conf)

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -53,9 +53,9 @@ class AssetProcessorService {
 	String getResolvedAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
 		final String relativePath = trimLeadingSlash(path)
 		if(manifest) {
-			relativePath ? manifest.getProperty(relativePath) : null
+			return relativePath ? manifest.getProperty(relativePath) : null
 		} else {
-			AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
+			return AssetHelper.fileForFullName(relativePath) != null ? relativePath : null
 		}
 	}
 

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -33,7 +33,7 @@ class AssetProcessorService {
 	 * @throws IllegalArgumentException if the path contains <code>/</code>
 	 */
 	String getAssetMapping() {
-		final def mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
+		final String mapping = grailsApplication.config?.grails?.assets?.mapping ?: 'assets'
 		if (mapping.contains('/')) {
 			throw new IllegalArgumentException(
 				'The property [grails.assets.mapping] can only be one level deep.  ' +
@@ -76,7 +76,7 @@ class AssetProcessorService {
 
 		url = assetBaseUrl(null, NONE) + url
 		if (! hasAuthority(url)) {
-			def absolutePath = linkGenerator.handleAbsolute(attrs)
+			String absolutePath = linkGenerator.handleAbsolute(attrs)
 
 			if (absolutePath == null) {
 				final String contextPath = attrs.contextPath?.toString() ?: linkGenerator.contextPath
@@ -117,7 +117,7 @@ class AssetProcessorService {
 				break
 		}
 
-		def finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
+		String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
 			.append(mapping)
 			.append('/' as char)
 			.toString()

--- a/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/grails-app/services/asset/pipeline/grails/AssetProcessorService.groovy
@@ -118,7 +118,7 @@ class AssetProcessorService {
 				break
 		}
 
-		String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
+		final String finalUrl = ensureEndsWith(new StringBuilder(baseUrl.length() + mapping.length() + 2).append(baseUrl), '/' as char)
 			.append(mapping)
 			.append('/' as char)
 			.toString()

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -6,10 +6,12 @@ import static asset.pipeline.grails.UrlBase.*
 
 class AssetMethodTagLib {
 
-	static namespace = 'g'
+	static namespace           = 'g'
 	static returnObjectForTags = ['assetPath']
 
+
 	def assetProcessorService
+
 
 	def assetPath = {final def attrs ->
 		final def     src

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -3,6 +3,7 @@ package asset.pipeline.grails
 
 import static asset.pipeline.grails.UrlBase.*
 
+
 class AssetMethodTagLib {
 
 	static namespace = 'g'

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -1,6 +1,8 @@
 package asset.pipeline.grails
 
 
+import asset.pipeline.AssetPaths
+
 import static org.apache.commons.lang.StringUtils.trimToEmpty
 
 
@@ -27,6 +29,6 @@ class AssetMethodTagLib {
 			baseUrl = trimToEmpty(grailsLinkGenerator.contextPath)
 		}
 
-		return assetProcessorService.assetBaseUrl(request, baseUrl) + assetProcessorService.getAssetPath(Objects.toString(src))
+		return assetProcessorService.assetBaseUrl(request, baseUrl) + AssetPaths.getAssetPath(Objects.toString(src))
 	}
 }

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -1,7 +1,7 @@
 package asset.pipeline.grails
 
 
-import static asset.pipeline.grails.UrlBase.*
+import static org.apache.commons.lang.StringUtils.trimToEmpty
 
 
 class AssetMethodTagLib {
@@ -11,21 +11,22 @@ class AssetMethodTagLib {
 
 
 	def assetProcessorService
+	def grailsLinkGenerator
 
 
 	def assetPath = {final def attrs ->
-		final def     src
-		final UrlBase urlBase
+		final def    src
+		final String baseUrl
 
 		if (attrs instanceof Map) {
 			src     = attrs.src
-			urlBase = attrs.absolute ? SERVER_BASE_URL : CONTEXT_PATH
+			baseUrl = attrs.absolute ? (grailsLinkGenerator.serverBaseURL ?: '') : trimToEmpty(grailsLinkGenerator.contextPath)
 		}
 		else {
 			src     = attrs
-			urlBase = CONTEXT_PATH
+			baseUrl = trimToEmpty(grailsLinkGenerator.contextPath)
 		}
 
-		return assetProcessorService.assetBaseUrl(request, urlBase) + assetProcessorService.getAssetPath(Objects.toString(src))
+		return assetProcessorService.assetBaseUrl(request, baseUrl) + assetProcessorService.getAssetPath(Objects.toString(src))
 	}
 }

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -1,11 +1,11 @@
 package asset.pipeline.grails
 
-import grails.util.Environment
-import grails.core.GrailsApplication
+
+import asset.pipeline.AssetHelper
+import asset.pipeline.AssetPaths
 import asset.pipeline.AssetPipeline
 import asset.pipeline.AssetPipelineConfigHolder
-import asset.pipeline.AssetHelper
-import asset.pipeline.AssetPipeline
+import grails.core.GrailsApplication
 import org.grails.buffer.GrailsPrintWriter
 
 
@@ -16,7 +16,6 @@ class AssetsTagLib {
 
 	private static final LINE_BREAK = System.getProperty('line.separator') ?: '\n'
 	GrailsApplication grailsApplication
-	def assetProcessorService
 
 
 	/**
@@ -62,7 +61,7 @@ class AssetsTagLib {
 		def conf = grailsApplication.config.grails.assets
 
 		final def nonBundledMode = (!AssetPipelineConfigHolder.manifest && conf.bundle != true && attrs.remove('bundle') != 'true')
-		
+
 		if (! nonBundledMode) {
 			output(src, '', attrs, '')
 		}
@@ -140,7 +139,7 @@ class AssetsTagLib {
 	}
 
 	boolean isAssetPath(src) {
-		assetProcessorService.isAssetPath(src)
+		AssetPaths.isAssetPath(src)
 	}
 
 	private paramsToHtmlAttr(attrs) {

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -15,6 +15,8 @@ class AssetsTagLib {
 	static returnObjectForTags = ['assetPath']
 
 	private static final LINE_BREAK = System.getProperty('line.separator') ?: '\n'
+
+
 	GrailsApplication grailsApplication
 
 
@@ -30,7 +32,6 @@ class AssetsTagLib {
 			} else {
 				outPw << '<script type="text/javascript" src="' << assetPath(src: src) << queryString << '" ' << paramsToHtmlAttr(outputAttrs) << '></script>' << endOfLine
 			}
-
 		}
 	}
 
@@ -61,7 +62,6 @@ class AssetsTagLib {
 		def conf = grailsApplication.config.grails.assets
 
 		final def nonBundledMode = (!AssetPipelineConfigHolder.manifest && conf.bundle != true && attrs.remove('bundle') != 'true')
-
 		if (! nonBundledMode) {
 			output(src, '', attrs, '')
 		}

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -21,7 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 @CompileStatic
 class AssetPipelineFilter extends OncePerRequestFilter {
 
-	public static final ProductionAssetCache fileCache = new ProductionAssetCache()
+	static final ProductionAssetCache fileCache = new ProductionAssetCache()
 	ApplicationContext applicationContext
 	ServletContext servletContext
 

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -145,7 +145,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 							response.setCharacterEncoding(encoding)
 						}
 						response.setContentType(format)
-						response.setHeader('Content-Length', file.contentLength().toString())
+						response.setHeader('Content-Length', String.valueOf(file.contentLength()))
 						final def inputStream
 						try {
 							final byte[] buffer = new byte[102400]
@@ -183,7 +183,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 				response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
 				response.setHeader("Pragma", "no-cache") // HTTP 1.0.
 				response.setDateHeader("Expires", 0) // Proxies.
-				response.setHeader('Content-Length', fileContents.size().toString())
+				response.setHeader('Content-Length', String.valueOf(fileContents.size()))
 
 				response.setContentType(format)
 				try {

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -1,4 +1,3 @@
-
 package asset.pipeline
 
 
@@ -22,15 +21,17 @@ import org.springframework.web.filter.OncePerRequestFilter
 class AssetPipelineFilter extends OncePerRequestFilter {
 
 	static final ProductionAssetCache fileCache = new ProductionAssetCache()
+
+
 	ApplicationContext applicationContext
 	ServletContext servletContext
+
 
 	@Override
 	void initFilterBean() throws ServletException {
 		def config = filterConfig
 		applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
 		servletContext = config.servletContext
-
 	}
 
 	@Override
@@ -47,6 +48,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 		if(fileUri.startsWith(baseAssetUrl)) {
 			fileUri = fileUri.substring(baseAssetUrl.length())
 		}
+
 		if(warDeployed) {
 			def manifest = AssetPipelineConfigHolder.manifest
 			def manifestPath = fileUri
@@ -60,10 +62,10 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 			if(attributeCache) {
 				if(attributeCache.exists()) {
 					def file = attributeCache.resource
-					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'),attributeCache.getLastModified())
+					def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'), attributeCache.getLastModified())
 
 					responseBuilder.headers.each { header ->
-						response.setHeader(header.key,header.value)
+						response.setHeader(header.key, header.value)
 					}
 
 					if(responseBuilder.statusCode) {
@@ -74,7 +76,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 						def acceptsEncoding = request.getHeader("Accept-Encoding")
 						if(acceptsEncoding?.split(",")?.contains("gzip") && attributeCache.gzipExists()) {
 							file = attributeCache.getGzipResource()
-							response.setHeader('Content-Encoding','gzip')
+							response.setHeader('Content-Encoding', 'gzip')
 							response.setHeader('Content-Length', attributeCache.getGzipFileSize().toString())
 						} else {
 							response.setHeader('Content-Length', attributeCache.getFileSize().toString())
@@ -90,12 +92,12 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 							int len
 							inputStream = file.inputStream
 							def out = response.outputStream
-							while ((len = inputStream.read(buffer)) != -1) {
+							while((len = inputStream.read(buffer)) != -1) {
 								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(e) {
-							log.debug("File Transfer Aborted (Probably by the user)",e)
+							log.debug("File Transfer Aborted (Probably by the user)", e)
 						} finally {
 							try { inputStream?.close() } catch(ie) { /* silent fail */}
 						}
@@ -106,7 +108,6 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 					response.status = 404
 					response.flushBuffer()
 				}
-
 			} else {
 				def file = applicationContext.getResource("assets/${fileUri}")
 				if(!file.exists()) {
@@ -114,13 +115,13 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 				}
 
 				if(file.exists()) {
-					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'),file.lastModified() ? new Date(file.lastModified()) : null)
+					def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'), file.lastModified() ? new Date(file.lastModified()) : null)
 
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
 					responseBuilder.headers.each { header ->
-						response.setHeader(header.key,header.value)
+						response.setHeader(header.key, header.value)
 					}
 
 					def gzipFile = applicationContext.getResource("assets/${fileUri}.gz")
@@ -137,7 +138,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 						if(acceptsEncoding?.split(",")?.contains("gzip")) {
 							if(gzipFile.exists()) {
 								file = gzipFile
-								response.setHeader('Content-Encoding','gzip')
+								response.setHeader('Content-Encoding', 'gzip')
 							}
 						}
 						if(encoding) {
@@ -151,12 +152,12 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 							int len
 							inputStream = file.inputStream
 							def out = response.outputStream
-							while ((len = inputStream.read(buffer)) != -1) {
+							while((len = inputStream.read(buffer)) != -1) {
 								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(e) {
-							log.debug("File Transfer Aborted (Probably by the user)",e)
+							log.debug("File Transfer Aborted (Probably by the user)", e)
 						} finally {
 							try { inputStream?.close() } catch(ie) { /* silent fail */}
 						}
@@ -173,13 +174,12 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 		} else {
 			def fileContents
 			if(request.getParameter('compile') == 'false') {
-				fileContents = AssetPipeline.serveUncompiledAsset(fileUri,format, null, encoding)
+				fileContents = AssetPipeline.serveUncompiledAsset(fileUri, format, null, encoding)
 			} else {
-				fileContents = AssetPipeline.serveAsset(fileUri,format, null, encoding)
+				fileContents = AssetPipeline.serveAsset(fileUri, format, null, encoding)
 			}
 
-			if (fileContents != null) {
-
+			if(fileContents != null) {
 				response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
 				response.setHeader("Pragma", "no-cache") // HTTP 1.0.
 				response.setDateHeader("Expires", 0) // Proxies.
@@ -190,7 +190,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 					response.outputStream << fileContents
 					response.flushBuffer()
 				} catch(e) {
-					log.debug("File Transfer Aborted (Probably by the user)",e)
+					log.debug("File Transfer Aborted (Probably by the user)", e)
 				}
 			} else {
 				response.status = 404
@@ -198,10 +198,8 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 			}
 		}
 
-		if (!response.committed) {
+		if(!response.committed) {
 			chain.doFilter(request, response)
 		}
 	}
-
-
 }

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -33,6 +33,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 
 	}
 
+	@Override
 	void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
 		boolean warDeployed = AssetPipelineConfigHolder.manifest ? true : false
 

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -20,92 +20,92 @@ import java.text.SimpleDateFormat
 @Commons
 @CompileStatic
 class AssetPipelineFilter extends OncePerRequestFilter {
-	
+
 	public static final ProductionAssetCache fileCache = new ProductionAssetCache();
-    ApplicationContext applicationContext
-    ServletContext servletContext
+	ApplicationContext applicationContext
+	ServletContext servletContext
 
-    @Override
-    void initFilterBean() throws ServletException {
-        def config = filterConfig
-        applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
-        servletContext = config.servletContext
+	@Override
+	void initFilterBean() throws ServletException {
+		def config = filterConfig
+		applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
+		servletContext = config.servletContext
 
-    }
+	}
 
-    void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-        boolean warDeployed = AssetPipelineConfigHolder.manifest ? true : false
+	void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+		boolean warDeployed = AssetPipelineConfigHolder.manifest ? true : false
 
-        String mapping = ((AssetProcessorService)(applicationContext.getBean('assetProcessorService', AssetProcessorService))).assetMapping
+		String mapping = ((AssetProcessorService)(applicationContext.getBean('assetProcessorService', AssetProcessorService))).assetMapping
 
-        def fileUri = new URI(request.requestURI).path
-        def baseAssetUrl = request.contextPath == "/" ? "/$mapping" : "${request.contextPath}/${mapping}"
-        def format = servletContext.getMimeType(fileUri)
-        def encoding = request.getParameter('encoding') ?: request.getCharacterEncoding()
+		def fileUri = new URI(request.requestURI).path
+		def baseAssetUrl = request.contextPath == "/" ? "/$mapping" : "${request.contextPath}/${mapping}"
+		def format = servletContext.getMimeType(fileUri)
+		def encoding = request.getParameter('encoding') ?: request.getCharacterEncoding()
 
-        if(fileUri.startsWith(baseAssetUrl)) {
-            fileUri = fileUri.substring(baseAssetUrl.length())
-        }
-        if(warDeployed) {
+		if(fileUri.startsWith(baseAssetUrl)) {
+			fileUri = fileUri.substring(baseAssetUrl.length())
+		}
+		if(warDeployed) {
 			def manifest = AssetPipelineConfigHolder.manifest
 			def manifestPath = fileUri
 			if(fileUri.startsWith('/')) {
-			  manifestPath = fileUri.substring(1) //Omit forward slash
+				manifestPath = fileUri.substring(1) //Omit forward slash
 			}
 			fileUri = manifest?.getProperty(manifestPath, manifestPath)
 
 			AssetAttributes attributeCache = fileCache.get(fileUri)
 
 			if(attributeCache) {
-                if(attributeCache.exists()) {
-                    def file = attributeCache.resource
-                    def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'),attributeCache.getLastModified())
-                    
-                    responseBuilder.headers.each { header ->
-                        response.setHeader(header.key,header.value)
-                    }
-                    
-                    if(responseBuilder.statusCode) {
-                        response.status = responseBuilder.statusCode
-                    }
+				if(attributeCache.exists()) {
+					def file = attributeCache.resource
+					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'),attributeCache.getLastModified())
 
-                    if(response.status != 304) {
-                        def acceptsEncoding = request.getHeader("Accept-Encoding")
-                        if(acceptsEncoding?.split(",")?.contains("gzip") && attributeCache.gzipExists()) {
-                            file = attributeCache.getGzipResource()
-                            response.setHeader('Content-Encoding','gzip')
-                            response.setHeader('Content-Length', attributeCache.getGzipFileSize().toString())
-                        } else {
-                            response.setHeader('Content-Length', attributeCache.getFileSize().toString())
-                        }
-                        if(encoding) {
-                            response.setCharacterEncoding(encoding)
-                        }
+					responseBuilder.headers.each { header ->
+						response.setHeader(header.key,header.value)
+					}
 
-                        response.setContentType(format)
-                        def inputStream
-                        try {
-                            byte[] buffer = new byte[102400];
-                            int len;
-                            inputStream = file.inputStream
-                            def out = response.outputStream
-                            while ((len = inputStream.read(buffer)) != -1) {
-                                out.write(buffer, 0, len);
-                            }
-                            response.flushBuffer()
-                        } catch(e) {
-                            log.debug("File Transfer Aborted (Probably by the user)",e)
-                        } finally {
-                            try { inputStream?.close() } catch(ie) { /* silent fail */}
-                        }
-                    } else {
-                        response.flushBuffer()
-                    }
-                } else {
-                    response.status = 404
-                    response.flushBuffer()
-                }
-				
+					if(responseBuilder.statusCode) {
+						response.status = responseBuilder.statusCode
+					}
+
+					if(response.status != 304) {
+						def acceptsEncoding = request.getHeader("Accept-Encoding")
+						if(acceptsEncoding?.split(",")?.contains("gzip") && attributeCache.gzipExists()) {
+							file = attributeCache.getGzipResource()
+							response.setHeader('Content-Encoding','gzip')
+							response.setHeader('Content-Length', attributeCache.getGzipFileSize().toString())
+						} else {
+							response.setHeader('Content-Length', attributeCache.getFileSize().toString())
+						}
+						if(encoding) {
+							response.setCharacterEncoding(encoding)
+						}
+
+						response.setContentType(format)
+						def inputStream
+						try {
+							byte[] buffer = new byte[102400];
+							int len;
+							inputStream = file.inputStream
+							def out = response.outputStream
+							while ((len = inputStream.read(buffer)) != -1) {
+								out.write(buffer, 0, len);
+							}
+							response.flushBuffer()
+						} catch(e) {
+							log.debug("File Transfer Aborted (Probably by the user)",e)
+						} finally {
+							try { inputStream?.close() } catch(ie) { /* silent fail */}
+						}
+					} else {
+						response.flushBuffer()
+					}
+				} else {
+					response.status = 404
+					response.flushBuffer()
+				}
+
 			} else {
 				def file = applicationContext.getResource("assets/${fileUri}")
 				if(!file.exists()) {
@@ -114,7 +114,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 
 				if(file.exists()) {
 					def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'),file.lastModified() ? new Date(file.lastModified()) : null)
-					
+
 					if(responseBuilder.statusCode) {
 						response.status = responseBuilder.statusCode
 					}
@@ -126,7 +126,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 					if(!gzipFile.exists()) {
 						gzipFile = applicationContext.getResource("classpath:assets/${fileUri}.gz")
 					}
-                    Date lastModifiedDate = file.lastModified() ? new Date(file.lastModified()) : null
+					Date lastModifiedDate = file.lastModified() ? new Date(file.lastModified()) : null
 					AssetAttributes newCache = new AssetAttributes(true, gzipFile.exists(), false, file.contentLength(), gzipFile.exists() ? gzipFile.contentLength() : null, lastModifiedDate, file, gzipFile)
 					fileCache.put(fileUri, newCache)
 
@@ -144,7 +144,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 						}
 						response.setContentType(format)
 						response.setHeader('Content-Length', file.contentLength().toString())
-                        def inputStream
+						def inputStream
 						try {
 							byte[] buffer = new byte[102400];
 							int len;
@@ -157,8 +157,8 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 						} catch(e) {
 							log.debug("File Transfer Aborted (Probably by the user)",e)
 						} finally {
-                            try { inputStream?.close() } catch(ie) { /* silent fail */}
-                        }
+							try { inputStream?.close() } catch(ie) { /* silent fail */}
+						}
 					} else {
 						response.flushBuffer()
 					}
@@ -169,38 +169,38 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 					response.flushBuffer()
 				}
 			}
-        } else {
-            def fileContents
-            if(request.getParameter('compile') == 'false') {
-                fileContents = AssetPipeline.serveUncompiledAsset(fileUri,format, null, encoding)
-            } else {
-                fileContents = AssetPipeline.serveAsset(fileUri,format, null, encoding)
-            }
+		} else {
+			def fileContents
+			if(request.getParameter('compile') == 'false') {
+				fileContents = AssetPipeline.serveUncompiledAsset(fileUri,format, null, encoding)
+			} else {
+				fileContents = AssetPipeline.serveAsset(fileUri,format, null, encoding)
+			}
 
-            if (fileContents != null) {
+			if (fileContents != null) {
 
-                response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
-                response.setHeader("Pragma", "no-cache") // HTTP 1.0.
-                response.setDateHeader("Expires", 0) // Proxies.
-                response.setHeader('Content-Length', fileContents.size().toString())
+				response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
+				response.setHeader("Pragma", "no-cache") // HTTP 1.0.
+				response.setDateHeader("Expires", 0) // Proxies.
+				response.setHeader('Content-Length', fileContents.size().toString())
 
-                response.setContentType(format)
-                try {
-                    response.outputStream << fileContents
-                    response.flushBuffer()
-                } catch(e) {
-                    log.debug("File Transfer Aborted (Probably by the user)",e)
-                }
-            } else {
-                response.status = 404
-                response.flushBuffer()
-            }
-        }
+				response.setContentType(format)
+				try {
+					response.outputStream << fileContents
+					response.flushBuffer()
+				} catch(e) {
+					log.debug("File Transfer Aborted (Probably by the user)",e)
+				}
+			} else {
+				response.status = 404
+				response.flushBuffer()
+			}
+		}
 
-        if (!response.committed) {
-            chain.doFilter(request, response)
-        }
-    }
+		if (!response.committed) {
+			chain.doFilter(request, response)
+		}
+	}
 
 
 }

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -21,7 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 @CompileStatic
 class AssetPipelineFilter extends OncePerRequestFilter {
 
-	public static final ProductionAssetCache fileCache = new ProductionAssetCache();
+	public static final ProductionAssetCache fileCache = new ProductionAssetCache()
 	ApplicationContext applicationContext
 	ServletContext servletContext
 
@@ -85,12 +85,12 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 						response.setContentType(format)
 						def inputStream
 						try {
-							byte[] buffer = new byte[102400];
-							int len;
+							byte[] buffer = new byte[102400]
+							int len
 							inputStream = file.inputStream
 							def out = response.outputStream
 							while ((len = inputStream.read(buffer)) != -1) {
-								out.write(buffer, 0, len);
+								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(e) {
@@ -146,12 +146,12 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 						response.setHeader('Content-Length', file.contentLength().toString())
 						def inputStream
 						try {
-							byte[] buffer = new byte[102400];
-							int len;
+							byte[] buffer = new byte[102400]
+							int len
 							inputStream = file.inputStream
 							def out = response.outputStream
 							while ((len = inputStream.read(buffer)) != -1) {
-								out.write(buffer, 0, len);
+								out.write(buffer, 0, len)
 							}
 							response.flushBuffer()
 						} catch(e) {

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -1,21 +1,21 @@
 
 package asset.pipeline
 
-import org.springframework.context.*
-import javax.servlet.*
-import javax.servlet.http.*
-import org.springframework.web.context.support.WebApplicationContextUtils
-import org.springframework.web.filter.*
-import groovy.util.logging.Commons
-import groovy.transform.*
-import asset.pipeline.grails.AssetProcessorService
-import asset.pipeline.AssetPipelineConfigHolder
-import asset.pipeline.AssetPipelineResponseBuilder
+
 import asset.pipeline.grails.AssetAttributes
+import asset.pipeline.grails.AssetProcessorService
 import asset.pipeline.grails.ProductionAssetCache
-import java.net.URI
-import java.util.TimeZone
-import java.text.SimpleDateFormat
+import groovy.transform.CompileStatic
+import groovy.util.logging.Commons
+import javax.servlet.FilterChain
+import javax.servlet.ServletContext
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import org.springframework.context.ApplicationContext
+import org.springframework.web.context.support.WebApplicationContextUtils
+import org.springframework.web.filter.OncePerRequestFilter
+
 
 @Commons
 @CompileStatic

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -1,5 +1,6 @@
 package asset.pipeline.grails
 
+
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.DirectiveProcessor
@@ -7,7 +8,6 @@ import asset.pipeline.GenericAssetFile
 import org.grails.core.io.DefaultResourceLocator
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.Resource
-import groovy.util.logging.Commons
 
 
 class AssetResourceLocator extends DefaultResourceLocator {

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -38,10 +38,10 @@ class AssetResourceLocator extends DefaultResourceLocator {
 			}
 		} else {
 			final List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			final String    contentType  = contentTypes ? contentTypes[0] : null
-			final String    extension    = AssetHelper.extensionFromURI(uri)
-			final String    name         = AssetHelper.nameWithoutExtension(uri)
-			final AssetFile assetFile    = AssetHelper.fileForUri(name, contentType, extension)
+			final String       contentType  = contentTypes ? contentTypes[0] : null
+			final String       extension    = AssetHelper.extensionFromURI(uri)
+			final String       name         = AssetHelper.nameWithoutExtension(uri)
+			final AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -1,6 +1,6 @@
 package asset.pipeline.grails
 
-
+import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.DirectiveProcessor
@@ -24,10 +24,10 @@ class AssetResourceLocator extends DefaultResourceLocator {
 	Resource findAssetForURI(String uri) {
 		Resource resource
 		if(warDeployed) {
-			def manifest = AssetPipelineConfigHolder.manifest
+			Properties manifest = AssetPipelineConfigHolder.manifest
 			uri = manifest?.getProperty(uri, uri)
 
-			def assetUri = "assets/${uri}"
+			String assetUri = "assets/${uri}"
 			Resource defaultResource = defaultResourceLoader.getResource(assetUri)
 			if (!defaultResource?.exists()) {
 				defaultResource = defaultResourceLoader.getResource("classpath:${assetUri}")
@@ -36,22 +36,22 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				resource = defaultResource
 			}
 		} else {
-			def contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			def contentType
+			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
+			String contentType
 			if(contentTypes) {
 				contentType = contentTypes[0]
 			}
 
-			def extension = AssetHelper.extensionFromURI(uri)
-			def name      = AssetHelper.nameWithoutExtension(uri)
-			def assetFile = AssetHelper.fileForUri(name, contentType, extension)
+			String    extension = AssetHelper.extensionFromURI(uri)
+			String    name      = AssetHelper.nameWithoutExtension(uri)
+			AssetFile assetFile = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)
 				} else {
-					def directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
+					DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
 					def fileContents = directiveProcessor.compile(assetFile)
-					def encoding = assetFile.encoding
+					String encoding = assetFile.encoding
 					if(encoding) {
 						resource = new ByteArrayResource(fileContents.getBytes(encoding))
 					} else {

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -11,6 +11,7 @@ import org.springframework.core.io.Resource
 
 
 class AssetResourceLocator extends DefaultResourceLocator {
+
 	Resource findResourceForURI(String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {
@@ -40,9 +41,9 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				contentType = contentTypes[0]
 			}
 
-			def extension    = AssetHelper.extensionFromURI(uri)
-			def name         = AssetHelper.nameWithoutExtension(uri)
-			def assetFile    = AssetHelper.fileForUri(name,contentType,extension)
+			def extension = AssetHelper.extensionFromURI(uri)
+			def name      = AssetHelper.nameWithoutExtension(uri)
+			def assetFile = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -38,9 +38,9 @@ class AssetResourceLocator extends DefaultResourceLocator {
 			}
 		} else {
 			final List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			final String contentType  = contentTypes ? contentTypes[0] : null
-			final String extension    = AssetHelper.extensionFromURI(uri)
-			final String name         = AssetHelper.nameWithoutExtension(uri)
+			final String    contentType  = contentTypes ? contentTypes[0] : null
+			final String    extension    = AssetHelper.extensionFromURI(uri)
+			final String    name         = AssetHelper.nameWithoutExtension(uri)
 			final AssetFile assetFile    = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -1,5 +1,6 @@
 package asset.pipeline.grails
 
+
 import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
@@ -13,7 +14,7 @@ import org.springframework.core.io.Resource
 class AssetResourceLocator extends DefaultResourceLocator {
 
 	@Override
-	Resource findResourceForURI(String uri) {
+	Resource findResourceForURI(final String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {
 			resource = findAssetForURI(uri)
@@ -22,12 +23,12 @@ class AssetResourceLocator extends DefaultResourceLocator {
 	}
 
 	Resource findAssetForURI(String uri) {
-		Resource resource
+		final Resource resource
 		if(warDeployed) {
-			Properties manifest = AssetPipelineConfigHolder.manifest
+			final Properties manifest = AssetPipelineConfigHolder.manifest
 			uri = manifest?.getProperty(uri, uri)
 
-			String assetUri = "assets/${uri}"
+			final String assetUri = "assets/${uri}"
 			Resource defaultResource = defaultResourceLoader.getResource(assetUri)
 			if (!defaultResource?.exists()) {
 				defaultResource = defaultResourceLoader.getResource("classpath:${assetUri}")
@@ -36,18 +37,18 @@ class AssetResourceLocator extends DefaultResourceLocator {
 				resource = defaultResource
 			}
 		} else {
-			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			String       contentType  = contentTypes ? contentTypes[0] : null
-			String       extension    = AssetHelper.extensionFromURI(uri)
-			String       name         = AssetHelper.nameWithoutExtension(uri)
-			AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
+			final List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
+			final String contentType  = contentTypes ? contentTypes[0] : null
+			final String extension    = AssetHelper.extensionFromURI(uri)
+			final String name         = AssetHelper.nameWithoutExtension(uri)
+			final AssetFile assetFile    = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)
 				} else {
-					DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
-					def fileContents = directiveProcessor.compile(assetFile)
-					String encoding = assetFile.encoding
+					final DirectiveProcessor directiveProcessor = new DirectiveProcessor(contentType, null, this.class.classLoader)
+					final def fileContents = directiveProcessor.compile(assetFile)
+					final String encoding = assetFile.encoding
 					if(encoding) {
 						resource = new ByteArrayResource(fileContents.getBytes(encoding))
 					} else {

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -37,14 +37,10 @@ class AssetResourceLocator extends DefaultResourceLocator {
 			}
 		} else {
 			List<String> contentTypes = AssetHelper.assetMimeTypeForURI(uri)
-			String contentType
-			if(contentTypes) {
-				contentType = contentTypes[0]
-			}
-
-			String    extension = AssetHelper.extensionFromURI(uri)
-			String    name      = AssetHelper.nameWithoutExtension(uri)
-			AssetFile assetFile = AssetHelper.fileForUri(name, contentType, extension)
+			String       contentType  = contentTypes ? contentTypes[0] : null
+			String       extension    = AssetHelper.extensionFromURI(uri)
+			String       name         = AssetHelper.nameWithoutExtension(uri)
+			AssetFile    assetFile    = AssetHelper.fileForUri(name, contentType, extension)
 			if(assetFile) {
 				if(assetFile instanceof GenericAssetFile) {
 					resource = new ByteArrayResource(assetFile.bytes)

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetResourceLocator.groovy
@@ -12,6 +12,7 @@ import org.springframework.core.io.Resource
 
 class AssetResourceLocator extends DefaultResourceLocator {
 
+	@Override
 	Resource findResourceForURI(String uri) {
 		Resource resource = super.findResourceForURI(uri)
 		if(!resource) {

--- a/asset-pipeline-grails/src/main/java/asset/pipeline/grails/UrlBase.java
+++ b/asset-pipeline-grails/src/main/java/asset/pipeline/grails/UrlBase.java
@@ -1,8 +1,0 @@
-package asset.pipeline.grails;
-
-
-public enum UrlBase {
-    SERVER_BASE_URL,
-    CONTEXT_PATH,
-    NONE
-}

--- a/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetMethodTagLibSpec.groovy
+++ b/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetMethodTagLibSpec.groovy
@@ -37,10 +37,8 @@ class AssetMethodTagLibSpec extends Specification {
 	def setup() {
 		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('application','grails-app/assets'))
 
-		assetProcessorService.grailsApplication   = grailsApplication
-		assetProcessorService.grailsLinkGenerator = [serverBaseURL: MOCK_BASE_SERVER_URL]
-
 		tagLib.assetProcessorService = assetProcessorService
+		tagLib.grailsLinkGenerator   = [serverBaseURL: MOCK_BASE_SERVER_URL]
 	}
 
 	void "should return assetPath"() {

--- a/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -22,12 +22,12 @@ import grails.test.mixin.TestFor
 import spock.lang.Specification
 
 
-
 /**
  * @author David Estes
  */
 @TestFor(AssetsTagLib)
 class AssetsTagLibSpec extends Specification {
+
 	private static final LINE_BREAK           = System.getProperty('line.separator') ?: '\n'
 	private static final MOCK_BASE_SERVER_URL = 'http://localhost:8080/foo'
 
@@ -38,13 +38,11 @@ class AssetsTagLibSpec extends Specification {
 	def setup() {
 		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('application', 'grails-app/assets'))
 
-		assetProcessorService.grailsApplication   = grailsApplication
-		assetProcessorService.grailsLinkGenerator = [serverBaseURL: MOCK_BASE_SERVER_URL]
-
 		final def assetMethodTagLibMock = mockTagLib(AssetMethodTagLib)
 		assetMethodTagLibMock.assetProcessorService = assetProcessorService
+		assetMethodTagLibMock.grailsLinkGenerator   = [serverBaseURL: MOCK_BASE_SERVER_URL]
 
-		tagLib.assetProcessorService = assetProcessorService
+		tagLib.grailsApplication = grailsApplication
 	}
 
 	void "should return assetPath"() {

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilter.groovy
@@ -1,11 +1,13 @@
 package asset.pipeline.servlet
 
+
 import javax.servlet.Filter
 import javax.servlet.FilterChain
 import javax.servlet.FilterConfig
 import javax.servlet.ServletException
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
+
 
 class AssetPipelineDevFilter implements Filter {
 	AssetPipelineDevFilterCore assetPipelineDevFilterCore = new AssetPipelineDevFilterCore()

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilter.groovy
@@ -8,24 +8,24 @@ import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 
 class AssetPipelineDevFilter implements Filter {
-    AssetPipelineDevFilterCore assetPipelineDevFilterCore = new AssetPipelineDevFilterCore()
+	AssetPipelineDevFilterCore assetPipelineDevFilterCore = new AssetPipelineDevFilterCore()
 
-    void setMapping(String mapping) {
-        assetPipelineDevFilterCore.mapping = mapping
-    }
+	void setMapping(String mapping) {
+		assetPipelineDevFilterCore.mapping = mapping
+	}
 
-    @Override
-    void init(FilterConfig filterConfig) throws ServletException {
-        assetPipelineDevFilterCore.servletContext = filterConfig.getServletContext()
-    }
+	@Override
+	void init(FilterConfig filterConfig) throws ServletException {
+		assetPipelineDevFilterCore.servletContext = filterConfig.getServletContext()
+	}
 
-    @Override
-    void destroy() {
+	@Override
+	void destroy() {
 
-    }
+	}
 
-    @Override
-    void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        assetPipelineDevFilterCore.doFilter(request, response, chain)
-    }
+	@Override
+	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		assetPipelineDevFilterCore.doFilter(request, response, chain)
+	}
 }

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilter.groovy
@@ -14,12 +14,12 @@ class AssetPipelineDevFilter implements Filter {
 	AssetPipelineDevFilterCore assetPipelineDevFilterCore = new AssetPipelineDevFilterCore()
 
 
-	void setMapping(String mapping) {
+	void setMapping(final String mapping) {
 		assetPipelineDevFilterCore.mapping = mapping
 	}
 
 	@Override
-	void init(FilterConfig filterConfig) throws ServletException {
+	void init(final FilterConfig filterConfig) throws ServletException {
 		assetPipelineDevFilterCore.servletContext = filterConfig.getServletContext()
 	}
 
@@ -28,7 +28,7 @@ class AssetPipelineDevFilter implements Filter {
 	}
 
 	@Override
-	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 		assetPipelineDevFilterCore.doFilter(request, response, chain)
 	}
 }

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilter.groovy
@@ -10,7 +10,9 @@ import javax.servlet.ServletResponse
 
 
 class AssetPipelineDevFilter implements Filter {
+
 	AssetPipelineDevFilterCore assetPipelineDevFilterCore = new AssetPipelineDevFilterCore()
+
 
 	void setMapping(String mapping) {
 		assetPipelineDevFilterCore.mapping = mapping
@@ -23,7 +25,6 @@ class AssetPipelineDevFilter implements Filter {
 
 	@Override
 	void destroy() {
-
 	}
 
 	@Override

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilterCore.groovy
@@ -12,42 +12,42 @@ import javax.servlet.http.HttpServletResponse
 import java.util.logging.Logger
 
 class AssetPipelineDevFilterCore {
-    private final static Logger log = Logger.getLogger(getClass().getName())
-    String mapping = "mapping"
-    ServletContext servletContext
+	private final static Logger log = Logger.getLogger(getClass().getName())
+	String mapping = "mapping"
+	ServletContext servletContext
 
-    void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        if (request instanceof HttpServletRequest) {
-            doFilterHttp(request, response, chain)
-        } else {
-            chain.doFilter(request, response)
-        }
-    }
+	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		if (request instanceof HttpServletRequest) {
+			doFilterHttp(request, response, chain)
+		} else {
+			chain.doFilter(request, response)
+		}
+	}
 
-    private void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
-        String fileUri = request.requestURI
-        String baseAssetUrl = request.contextPath == "/" ? "/$mapping/" : "${request.contextPath}/${mapping}/"
-        if (fileUri.startsWith(baseAssetUrl)) {
-            fileUri = fileUri.substring(baseAssetUrl.length())
-        }
-        String format = servletContext.getMimeType(request.requestURI)
+	private void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+		String fileUri = request.requestURI
+		String baseAssetUrl = request.contextPath == "/" ? "/$mapping/" : "${request.contextPath}/${mapping}/"
+		if (fileUri.startsWith(baseAssetUrl)) {
+			fileUri = fileUri.substring(baseAssetUrl.length())
+		}
+		String format = servletContext.getMimeType(request.requestURI)
 
-        byte[] fileContents = AssetPipeline.serveAsset(fileUri, format, null, request.characterEncoding)
-        if (fileContents) {
-            response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
-            response.setHeader("Pragma", "no-cache"); // HTTP 1.0.
-            response.setDateHeader("Expires", 0); // Proxies.
-            response.setContentType(format)
-            try {
-                response.outputStream << fileContents
-                response.flushBuffer()
-            } catch (e) {
-                log.fine("File Transfer Aborted (Probably by the user): ${e.getMessage()}")
-            }
-        }
+		byte[] fileContents = AssetPipeline.serveAsset(fileUri, format, null, request.characterEncoding)
+		if (fileContents) {
+			response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
+			response.setHeader("Pragma", "no-cache"); // HTTP 1.0.
+			response.setDateHeader("Expires", 0); // Proxies.
+			response.setContentType(format)
+			try {
+				response.outputStream << fileContents
+				response.flushBuffer()
+			} catch (e) {
+				log.fine("File Transfer Aborted (Probably by the user): ${e.getMessage()}")
+			}
+		}
 
-        if (!response.committed) {
-            filterChain.doFilter(request, response)
-        }
-    }
+		if (!response.committed) {
+			filterChain.doFilter(request, response)
+		}
+	}
 }

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilterCore.groovy
@@ -1,7 +1,8 @@
 package asset.pipeline.servlet
 
-import asset.pipeline.AssetPipeline
 
+import asset.pipeline.AssetPipeline
+import java.util.logging.Logger
 import javax.servlet.FilterChain
 import javax.servlet.ServletContext
 import javax.servlet.ServletException
@@ -9,7 +10,7 @@ import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import java.util.logging.Logger
+
 
 class AssetPipelineDevFilterCore {
 	private final static Logger log = Logger.getLogger(getClass().getName())

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilterCore.groovy
@@ -21,7 +21,7 @@ class AssetPipelineDevFilterCore {
 	ServletContext servletContext
 
 
-	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 		if(request instanceof HttpServletRequest) {
 			doFilterHttp(request, response, chain)
 		} else {
@@ -29,15 +29,15 @@ class AssetPipelineDevFilterCore {
 		}
 	}
 
-	private void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+	private void doFilterHttp(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain) {
 		String fileUri = request.requestURI
-		String baseAssetUrl = request.contextPath == "/" ? "/$mapping/" : "${request.contextPath}/${mapping}/"
+		final String baseAssetUrl = request.contextPath == "/" ? "/$mapping/" : "${request.contextPath}/${mapping}/"
 		if(fileUri.startsWith(baseAssetUrl)) {
 			fileUri = fileUri.substring(baseAssetUrl.length())
 		}
-		String format = servletContext.getMimeType(request.requestURI)
+		final String format = servletContext.getMimeType(request.requestURI)
 
-		byte[] fileContents = AssetPipeline.serveAsset(fileUri, format, null, request.characterEncoding)
+		final byte[] fileContents = AssetPipeline.serveAsset(fileUri, format, null, request.characterEncoding)
 		if(fileContents) {
 			response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
 			response.setHeader("Pragma", "no-cache"); // HTTP 1.0.
@@ -46,7 +46,7 @@ class AssetPipelineDevFilterCore {
 			try {
 				response.outputStream << fileContents
 				response.flushBuffer()
-			} catch(e) {
+			} catch(final e) {
 				log.fine("File Transfer Aborted (Probably by the user): ${e.getMessage()}")
 			}
 		}

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineDevFilterCore.groovy
@@ -13,12 +13,16 @@ import javax.servlet.http.HttpServletResponse
 
 
 class AssetPipelineDevFilterCore {
+
 	private final static Logger log = Logger.getLogger(getClass().getName())
+
+
 	String mapping = "mapping"
 	ServletContext servletContext
 
+
 	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-		if (request instanceof HttpServletRequest) {
+		if(request instanceof HttpServletRequest) {
 			doFilterHttp(request, response, chain)
 		} else {
 			chain.doFilter(request, response)
@@ -28,13 +32,13 @@ class AssetPipelineDevFilterCore {
 	private void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
 		String fileUri = request.requestURI
 		String baseAssetUrl = request.contextPath == "/" ? "/$mapping/" : "${request.contextPath}/${mapping}/"
-		if (fileUri.startsWith(baseAssetUrl)) {
+		if(fileUri.startsWith(baseAssetUrl)) {
 			fileUri = fileUri.substring(baseAssetUrl.length())
 		}
 		String format = servletContext.getMimeType(request.requestURI)
 
 		byte[] fileContents = AssetPipeline.serveAsset(fileUri, format, null, request.characterEncoding)
-		if (fileContents) {
+		if(fileContents) {
 			response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
 			response.setHeader("Pragma", "no-cache"); // HTTP 1.0.
 			response.setDateHeader("Expires", 0); // Proxies.
@@ -42,12 +46,12 @@ class AssetPipelineDevFilterCore {
 			try {
 				response.outputStream << fileContents
 				response.flushBuffer()
-			} catch (e) {
+			} catch(e) {
 				log.fine("File Transfer Aborted (Probably by the user): ${e.getMessage()}")
 			}
 		}
 
-		if (!response.committed) {
+		if(!response.committed) {
 			filterChain.doFilter(request, response)
 		}
 	}

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilter.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilter.groovy
@@ -14,16 +14,16 @@ class AssetPipelineFilter implements Filter {
 	AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()
 
 
-	void setAssetPipelineServletResourceRepository(AssetPipelineServletResourceRepository assetPipelineServletResourceRepository) {
+	void setAssetPipelineServletResourceRepository(final AssetPipelineServletResourceRepository assetPipelineServletResourceRepository) {
 		assetPipelineFilterCore.assetPipelineServletResourceRepository = assetPipelineServletResourceRepository
 	}
 
-	void setMapping(String mapping) {
+	void setMapping(final String mapping) {
 		assetPipelineFilterCore.mapping = mapping
 	}
 
 	@Override
-	void init(FilterConfig filterConfig) throws ServletException {
+	void init(final FilterConfig filterConfig) throws ServletException {
 		assetPipelineFilterCore.servletContext = filterConfig.getServletContext()
 	}
 
@@ -32,7 +32,7 @@ class AssetPipelineFilter implements Filter {
 	}
 
 	@Override
-	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 		assetPipelineFilterCore.doFilter(request, response, chain)
 	}
 }

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilter.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilter.groovy
@@ -8,29 +8,29 @@ import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 
 class AssetPipelineFilter implements Filter {
-    AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()
+	AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()
 
 
-    void setAssetPipelineServletResourceRepository(AssetPipelineServletResourceRepository assetPipelineServletResourceRepository) {
-        assetPipelineFilterCore.assetPipelineServletResourceRepository = assetPipelineServletResourceRepository
-    }
+	void setAssetPipelineServletResourceRepository(AssetPipelineServletResourceRepository assetPipelineServletResourceRepository) {
+		assetPipelineFilterCore.assetPipelineServletResourceRepository = assetPipelineServletResourceRepository
+	}
 
-    void setMapping(String mapping) {
-        assetPipelineFilterCore.mapping = mapping
-    }
+	void setMapping(String mapping) {
+		assetPipelineFilterCore.mapping = mapping
+	}
 
-    @Override
-    void init(FilterConfig filterConfig) throws ServletException {
-        assetPipelineFilterCore.servletContext = filterConfig.getServletContext()
-    }
+	@Override
+	void init(FilterConfig filterConfig) throws ServletException {
+		assetPipelineFilterCore.servletContext = filterConfig.getServletContext()
+	}
 
-    @Override
-    void destroy() {
+	@Override
+	void destroy() {
 
-    }
+	}
 
-    @Override
-    void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        assetPipelineFilterCore.doFilter(request, response, chain)
-    }
+	@Override
+	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		assetPipelineFilterCore.doFilter(request, response, chain)
+	}
 }

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilter.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilter.groovy
@@ -1,11 +1,13 @@
 package asset.pipeline.servlet
 
+
 import javax.servlet.Filter
 import javax.servlet.FilterChain
 import javax.servlet.FilterConfig
 import javax.servlet.ServletException
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
+
 
 class AssetPipelineFilter implements Filter {
 	AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilter.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilter.groovy
@@ -10,6 +10,7 @@ import javax.servlet.ServletResponse
 
 
 class AssetPipelineFilter implements Filter {
+
 	AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()
 
 
@@ -28,7 +29,6 @@ class AssetPipelineFilter implements Filter {
 
 	@Override
 	void destroy() {
-
 	}
 
 	@Override

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
@@ -69,12 +69,12 @@ class AssetPipelineFilterCore {
 				response.setContentType(format)
 				def inputStream
 				try {
-					byte[] buffer = new byte[102400];
-					int len;
+					byte[] buffer = new byte[102400]
+					int len
 					inputStream = resource.inputStream
 					def out = response.outputStream
 					while ((len = inputStream.read(buffer)) != -1) {
-						out.write(buffer, 0, len);
+						out.write(buffer, 0, len)
 					}
 					response.flushBuffer()
 				} catch (e) {

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
@@ -1,7 +1,8 @@
 package asset.pipeline.servlet
 
-import asset.pipeline.AssetPipelineConfigHolder
 
+import asset.pipeline.AssetPipelineResponseBuilder
+import java.util.logging.Logger
 import javax.servlet.FilterChain
 import javax.servlet.ServletContext
 import javax.servlet.ServletException
@@ -9,9 +10,7 @@ import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import java.text.SimpleDateFormat
-import java.util.logging.Logger
-import asset.pipeline.AssetPipelineResponseBuilder
+
 
 class AssetPipelineFilterCore {
 	private static final Logger log = Logger.getLogger(getClass().getName())

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletResponse
 
 class AssetPipelineFilterCore {
 	private static final Logger log = Logger.getLogger(getClass().getName())
-	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
+	static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
 	String mapping = "mapping"
 	AssetPipelineServletResourceRepository assetPipelineServletResourceRepository

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
@@ -13,15 +13,18 @@ import javax.servlet.http.HttpServletResponse
 
 
 class AssetPipelineFilterCore {
+
 	private static final Logger log = Logger.getLogger(getClass().getName())
 	static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
+
 
 	String mapping = "mapping"
 	AssetPipelineServletResourceRepository assetPipelineServletResourceRepository
 	ServletContext servletContext
 
+
 	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-		if (request instanceof HttpServletRequest) {
+		if(request instanceof HttpServletRequest) {
 			doFilterHttp(request, response, chain)
 		} else {
 			chain.doFilter(request, response)
@@ -29,41 +32,40 @@ class AssetPipelineFilterCore {
 	}
 
 	private void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
-		if (assetPipelineServletResourceRepository == null) {
+		if(assetPipelineServletResourceRepository == null) {
 			throw new IllegalStateException("Property 'assetPipelineServletResourceRepository' is null")
 		}
 
 		String fileUri = request.requestURI
 		String baseAssetUrl = request.contextPath == "/" ? "/$mapping" : "${request.contextPath}/${mapping}"
-		if (fileUri.startsWith(baseAssetUrl)) {
+		if(fileUri.startsWith(baseAssetUrl)) {
 			fileUri = fileUri.substring(baseAssetUrl.length())
 		}
 
 		AssetPipelineServletResource resource = assetPipelineServletResourceRepository.getResource(fileUri)
-		if (resource) {
+		if(resource) {
 			Date lastModifiedDate = resource.getLastModified() ? new Date(resource.getLastModified()) : null
-			def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'), lastModifiedDate)
+			def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'), lastModifiedDate)
 			responseBuilder.headers.each { header ->
-				response.setHeader(header.key,header.value)
+				response.setHeader(header.key, header.value)
 			}
 			if(responseBuilder.statusCode) {
 				response.status = responseBuilder.statusCode
 			}
 
-
-			if (response.status != 304) {
+			if(response.status != 304) {
 				// Check for GZip
 				def acceptsEncoding = request.getHeader("Accept-Encoding")
-				if (acceptsEncoding?.split(",")?.contains("gzip")) {
+				if(acceptsEncoding?.split(",")?.contains("gzip")) {
 					AssetPipelineServletResource gzipResource = assetPipelineServletResourceRepository.getGzippedResource(fileUri)
-					if (gzipResource) {
+					if(gzipResource) {
 						resource = gzipResource
 						response.setHeader('Content-Encoding', 'gzip')
 					}
 				}
 				def format = servletContext.getMimeType(request.requestURI)
 				def encoding = request.getCharacterEncoding()
-				if (encoding) {
+				if(encoding) {
 					response.setCharacterEncoding(encoding)
 				}
 				response.setContentType(format)
@@ -73,11 +75,11 @@ class AssetPipelineFilterCore {
 					int len
 					inputStream = resource.inputStream
 					def out = response.outputStream
-					while ((len = inputStream.read(buffer)) != -1) {
+					while((len = inputStream.read(buffer)) != -1) {
 						out.write(buffer, 0, len)
 					}
 					response.flushBuffer()
-				} catch (e) {
+				} catch(e) {
 					log.fine("File Transfer Aborted (Probably by the user): ${e.getMessage()}")
 				} finally {
 					try { inputStream?.close() } catch(ie) { /* silent fail*/}
@@ -87,9 +89,8 @@ class AssetPipelineFilterCore {
 			}
 		}
 
-		if (!response.committed) {
+		if(!response.committed) {
 			filterChain.doFilter(request, response)
 		}
 	}
-
 }

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
@@ -23,7 +23,7 @@ class AssetPipelineFilterCore {
 	ServletContext servletContext
 
 
-	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 		if(request instanceof HttpServletRequest) {
 			doFilterHttp(request, response, chain)
 		} else {
@@ -31,22 +31,22 @@ class AssetPipelineFilterCore {
 		}
 	}
 
-	private void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+	private void doFilterHttp(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain) {
 		if(assetPipelineServletResourceRepository == null) {
 			throw new IllegalStateException("Property 'assetPipelineServletResourceRepository' is null")
 		}
 
 		String fileUri = request.requestURI
-		String baseAssetUrl = request.contextPath == "/" ? "/$mapping" : "${request.contextPath}/${mapping}"
+		final String baseAssetUrl = request.contextPath == "/" ? "/$mapping" : "${request.contextPath}/${mapping}"
 		if(fileUri.startsWith(baseAssetUrl)) {
 			fileUri = fileUri.substring(baseAssetUrl.length())
 		}
 
 		AssetPipelineServletResource resource = assetPipelineServletResourceRepository.getResource(fileUri)
 		if(resource) {
-			Date lastModifiedDate = resource.getLastModified() ? new Date(resource.getLastModified()) : null
-			def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'), lastModifiedDate)
-			responseBuilder.headers.each { header ->
+			final Date lastModifiedDate = resource.getLastModified() ? new Date(resource.getLastModified()) : null
+			final def responseBuilder = new AssetPipelineResponseBuilder(fileUri, request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'), lastModifiedDate)
+			responseBuilder.headers.each { final header ->
 				response.setHeader(header.key, header.value)
 			}
 			if(responseBuilder.statusCode) {
@@ -55,34 +55,34 @@ class AssetPipelineFilterCore {
 
 			if(response.status != 304) {
 				// Check for GZip
-				def acceptsEncoding = request.getHeader("Accept-Encoding")
+				final def acceptsEncoding = request.getHeader("Accept-Encoding")
 				if(acceptsEncoding?.split(",")?.contains("gzip")) {
-					AssetPipelineServletResource gzipResource = assetPipelineServletResourceRepository.getGzippedResource(fileUri)
+					final AssetPipelineServletResource gzipResource = assetPipelineServletResourceRepository.getGzippedResource(fileUri)
 					if(gzipResource) {
 						resource = gzipResource
 						response.setHeader('Content-Encoding', 'gzip')
 					}
 				}
-				def format = servletContext.getMimeType(request.requestURI)
-				def encoding = request.getCharacterEncoding()
+				final def format = servletContext.getMimeType(request.requestURI)
+				final def encoding = request.getCharacterEncoding()
 				if(encoding) {
 					response.setCharacterEncoding(encoding)
 				}
 				response.setContentType(format)
-				def inputStream
+				final def inputStream
 				try {
-					byte[] buffer = new byte[102400]
+					final byte[] buffer = new byte[102400]
 					int len
 					inputStream = resource.inputStream
-					def out = response.outputStream
+					final def out = response.outputStream
 					while((len = inputStream.read(buffer)) != -1) {
 						out.write(buffer, 0, len)
 					}
 					response.flushBuffer()
-				} catch(e) {
+				} catch(final e) {
 					log.fine("File Transfer Aborted (Probably by the user): ${e.getMessage()}")
 				} finally {
-					try { inputStream?.close() } catch(ie) { /* silent fail*/}
+					try { inputStream?.close() } catch(final ie) { /* silent fail*/}
 				}
 			} else {
 				response.flushBuffer()

--- a/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
+++ b/asset-pipeline-servlet/src/main/groovy/asset/pipeline/servlet/AssetPipelineFilterCore.groovy
@@ -14,35 +14,35 @@ import java.util.logging.Logger
 import asset.pipeline.AssetPipelineResponseBuilder
 
 class AssetPipelineFilterCore {
-    private static final Logger log = Logger.getLogger(getClass().getName())
-    public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
+	private static final Logger log = Logger.getLogger(getClass().getName())
+	public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
-    String mapping = "mapping"
-    AssetPipelineServletResourceRepository assetPipelineServletResourceRepository
-    ServletContext servletContext
+	String mapping = "mapping"
+	AssetPipelineServletResourceRepository assetPipelineServletResourceRepository
+	ServletContext servletContext
 
-    void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        if (request instanceof HttpServletRequest) {
-            doFilterHttp(request, response, chain)
-        } else {
-            chain.doFilter(request, response)
-        }
-    }
+	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		if (request instanceof HttpServletRequest) {
+			doFilterHttp(request, response, chain)
+		} else {
+			chain.doFilter(request, response)
+		}
+	}
 
-    private void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
-        if (assetPipelineServletResourceRepository == null) {
-            throw new IllegalStateException("Property 'assetPipelineServletResourceRepository' is null")
-        }
+	private void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+		if (assetPipelineServletResourceRepository == null) {
+			throw new IllegalStateException("Property 'assetPipelineServletResourceRepository' is null")
+		}
 
-        String fileUri = request.requestURI
-        String baseAssetUrl = request.contextPath == "/" ? "/$mapping" : "${request.contextPath}/${mapping}"
-        if (fileUri.startsWith(baseAssetUrl)) {
-            fileUri = fileUri.substring(baseAssetUrl.length())
-        }
+		String fileUri = request.requestURI
+		String baseAssetUrl = request.contextPath == "/" ? "/$mapping" : "${request.contextPath}/${mapping}"
+		if (fileUri.startsWith(baseAssetUrl)) {
+			fileUri = fileUri.substring(baseAssetUrl.length())
+		}
 
-        AssetPipelineServletResource resource = assetPipelineServletResourceRepository.getResource(fileUri)
-        if (resource) {
-            Date lastModifiedDate = resource.getLastModified() ? new Date(resource.getLastModified()) : null
+		AssetPipelineServletResource resource = assetPipelineServletResourceRepository.getResource(fileUri)
+		if (resource) {
+			Date lastModifiedDate = resource.getLastModified() ? new Date(resource.getLastModified()) : null
 			def responseBuilder = new AssetPipelineResponseBuilder(fileUri,request.getHeader('If-None-Match'), request.getHeader('If-Modified-Since'), lastModifiedDate)
 			responseBuilder.headers.each { header ->
 				response.setHeader(header.key,header.value)
@@ -53,23 +53,23 @@ class AssetPipelineFilterCore {
 
 
 			if (response.status != 304) {
-                // Check for GZip
-                def acceptsEncoding = request.getHeader("Accept-Encoding")
-                if (acceptsEncoding?.split(",")?.contains("gzip")) {
-                    AssetPipelineServletResource gzipResource = assetPipelineServletResourceRepository.getGzippedResource(fileUri)
-                    if (gzipResource) {
-                        resource = gzipResource
-                        response.setHeader('Content-Encoding', 'gzip')
-                    }
-                }
-                def format = servletContext.getMimeType(request.requestURI)
-                def encoding = request.getCharacterEncoding()
-                if (encoding) {
-                    response.setCharacterEncoding(encoding)
-                }
-                response.setContentType(format)
-                def inputStream
-                try {
+				// Check for GZip
+				def acceptsEncoding = request.getHeader("Accept-Encoding")
+				if (acceptsEncoding?.split(",")?.contains("gzip")) {
+					AssetPipelineServletResource gzipResource = assetPipelineServletResourceRepository.getGzippedResource(fileUri)
+					if (gzipResource) {
+						resource = gzipResource
+						response.setHeader('Content-Encoding', 'gzip')
+					}
+				}
+				def format = servletContext.getMimeType(request.requestURI)
+				def encoding = request.getCharacterEncoding()
+				if (encoding) {
+					response.setCharacterEncoding(encoding)
+				}
+				response.setContentType(format)
+				def inputStream
+				try {
 					byte[] buffer = new byte[102400];
 					int len;
 					inputStream = resource.inputStream
@@ -77,20 +77,20 @@ class AssetPipelineFilterCore {
 					while ((len = inputStream.read(buffer)) != -1) {
 						out.write(buffer, 0, len);
 					}
-                    response.flushBuffer()
-                } catch (e) {
-                    log.fine("File Transfer Aborted (Probably by the user): ${e.getMessage()}")
-                } finally {
-                    try { inputStream?.close() } catch(ie) { /* silent fail*/} 
-                }
-            } else {
+					response.flushBuffer()
+				} catch (e) {
+					log.fine("File Transfer Aborted (Probably by the user): ${e.getMessage()}")
+				} finally {
+					try { inputStream?.close() } catch(ie) { /* silent fail*/}
+				}
+			} else {
 				response.flushBuffer()
 			}
-        }
+		}
 
-        if (!response.committed) {
-            filterChain.doFilter(request, response)
-        }
-    }
+		if (!response.committed) {
+			filterChain.doFilter(request, response)
+		}
+	}
 
 }

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
@@ -15,14 +15,17 @@ import javax.servlet.ServletResponse
 class AssetPipelineDevFilter implements Filter {
 	AssetPipelineDevFilterCore assetPipelineDevFilterCoreStandalone = new AssetPipelineDevFilterCore()
 
+	@Override
 	void init(FilterConfig config) throws ServletException {
 		assetPipelineDevFilterCoreStandalone.servletContext = config.servletContext
 		assetPipelineDevFilterCoreStandalone.mapping = "assets"
 	}
 
+	@Override
 	void destroy() {
 	}
 
+	@Override
 	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		assetPipelineDevFilterCoreStandalone.doFilter(request, response, chain)
 	}

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
@@ -1,9 +1,15 @@
 package asset.pipeline.springboot
 
+
 import asset.pipeline.servlet.AssetPipelineDevFilterCore
 import groovy.util.logging.Log4j
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
 
-import javax.servlet.*
 
 @Log4j
 class AssetPipelineDevFilter implements Filter {

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
@@ -13,7 +13,9 @@ import javax.servlet.ServletResponse
 
 @Log4j
 class AssetPipelineDevFilter implements Filter {
+
 	AssetPipelineDevFilterCore assetPipelineDevFilterCoreStandalone = new AssetPipelineDevFilterCore()
+
 
 	@Override
 	void init(FilterConfig config) throws ServletException {
@@ -29,5 +31,4 @@ class AssetPipelineDevFilter implements Filter {
 	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		assetPipelineDevFilterCoreStandalone.doFilter(request, response, chain)
 	}
-
 }

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
@@ -18,7 +18,7 @@ class AssetPipelineDevFilter implements Filter {
 
 
 	@Override
-	void init(FilterConfig config) throws ServletException {
+	void init(final FilterConfig config) throws ServletException {
 		assetPipelineDevFilterCoreStandalone.servletContext = config.servletContext
 		assetPipelineDevFilterCoreStandalone.mapping = "assets"
 	}
@@ -28,7 +28,7 @@ class AssetPipelineDevFilter implements Filter {
 	}
 
 	@Override
-	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 		assetPipelineDevFilterCoreStandalone.doFilter(request, response, chain)
 	}
 }

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineDevFilter.groovy
@@ -7,18 +7,18 @@ import javax.servlet.*
 
 @Log4j
 class AssetPipelineDevFilter implements Filter {
-    AssetPipelineDevFilterCore assetPipelineDevFilterCoreStandalone = new AssetPipelineDevFilterCore()
+	AssetPipelineDevFilterCore assetPipelineDevFilterCoreStandalone = new AssetPipelineDevFilterCore()
 
-    void init(FilterConfig config) throws ServletException {
-        assetPipelineDevFilterCoreStandalone.servletContext = config.servletContext
-        assetPipelineDevFilterCoreStandalone.mapping = "assets"
-    }
+	void init(FilterConfig config) throws ServletException {
+		assetPipelineDevFilterCoreStandalone.servletContext = config.servletContext
+		assetPipelineDevFilterCoreStandalone.mapping = "assets"
+	}
 
-    void destroy() {
-    }
+	void destroy() {
+	}
 
-    void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        assetPipelineDevFilterCoreStandalone.doFilter(request, response, chain)
-    }
+	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		assetPipelineDevFilterCoreStandalone.doFilter(request, response, chain)
+	}
 
 }

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
@@ -37,7 +37,7 @@ class AssetPipelineFilter implements Filter {
 
 	private static final class SpringServletResourceRepository implements AssetPipelineServletResourceRepository {
 		private final WebApplicationContext applicationContext
-		public SpringServletResourceRepository(WebApplicationContext applicationContext) {
+		SpringServletResourceRepository(WebApplicationContext applicationContext) {
 			this.applicationContext = applicationContext
 		}
 

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
@@ -16,63 +16,63 @@ import org.springframework.web.context.WebApplicationContext
 
 @Log4j
 class AssetPipelineFilter implements Filter {
-    AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()
+	AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()
 
-    void init(FilterConfig config) throws ServletException {
-        assetPipelineFilterCore.servletContext = config.servletContext
-        assetPipelineFilterCore.mapping = "assets"
+	void init(FilterConfig config) throws ServletException {
+		assetPipelineFilterCore.servletContext = config.servletContext
+		assetPipelineFilterCore.mapping = "assets"
 
-        WebApplicationContext applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
-        assetPipelineFilterCore.assetPipelineServletResourceRepository = new SpringServletResourceRepository(applicationContext)
-    }
+		WebApplicationContext applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
+		assetPipelineFilterCore.assetPipelineServletResourceRepository = new SpringServletResourceRepository(applicationContext)
+	}
 
-    void destroy() {
-    }
+	void destroy() {
+	}
 
-    void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        assetPipelineFilterCore.doFilter(request, response, chain)
-    }
+	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		assetPipelineFilterCore.doFilter(request, response, chain)
+	}
 
-    private static final class SpringServletResourceRepository implements AssetPipelineServletResourceRepository {
-        private final WebApplicationContext applicationContext
-        public SpringServletResourceRepository(WebApplicationContext applicationContext) {
-            this.applicationContext = applicationContext
-        }
+	private static final class SpringServletResourceRepository implements AssetPipelineServletResourceRepository {
+		private final WebApplicationContext applicationContext
+		public SpringServletResourceRepository(WebApplicationContext applicationContext) {
+			this.applicationContext = applicationContext
+		}
 
-        @Override
-        AssetPipelineServletResource getResource(String path) {
-            return SpringServletResource.create(applicationContext.getResource("classpath:assets${path}"))
-        }
+		@Override
+		AssetPipelineServletResource getResource(String path) {
+			return SpringServletResource.create(applicationContext.getResource("classpath:assets${path}"))
+		}
 
-        @Override
-        AssetPipelineServletResource getGzippedResource(String path) {
-            return SpringServletResource.create(applicationContext.getResource("assets${path}.gz"))
-        }
-    }
+		@Override
+		AssetPipelineServletResource getGzippedResource(String path) {
+			return SpringServletResource.create(applicationContext.getResource("assets${path}.gz"))
+		}
+	}
 
-    private static final class SpringServletResource implements AssetPipelineServletResource {
-        private final Resource resource
+	private static final class SpringServletResource implements AssetPipelineServletResource {
+		private final Resource resource
 
-        private SpringServletResource(Resource resource) {
-            this.resource = resource
-        }
+		private SpringServletResource(Resource resource) {
+			this.resource = resource
+		}
 
-        static SpringServletResource create(Resource resource) {
-            if (!resource.exists()) {
-                return null
-            }
+		static SpringServletResource create(Resource resource) {
+			if (!resource.exists()) {
+				return null
+			}
 
-            new SpringServletResource(resource)
-        }
+			new SpringServletResource(resource)
+		}
 
-        @Override
-        Long getLastModified() {
-            return resource.lastModified()
-        }
+		@Override
+		Long getLastModified() {
+			return resource.lastModified()
+		}
 
-        @Override
-        InputStream getInputStream() {
-            return resource.getInputStream()
-        }
-    }
+		@Override
+		InputStream getInputStream() {
+			return resource.getInputStream()
+		}
+	}
 }

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
@@ -1,18 +1,20 @@
 package asset.pipeline.springboot
 
-import asset.pipeline.AssetPipelineConfigHolder
-import asset.pipeline.AssetPipelineResponseBuilder
+
 import asset.pipeline.servlet.AssetPipelineFilterCore
 import asset.pipeline.servlet.AssetPipelineServletResource
 import asset.pipeline.servlet.AssetPipelineServletResourceRepository
 import groovy.util.logging.Log4j
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
 import org.springframework.core.io.Resource
 import org.springframework.web.context.WebApplicationContext
 import org.springframework.web.context.support.WebApplicationContextUtils
 
-import javax.servlet.*
-import java.text.SimpleDateFormat
-import org.springframework.web.context.WebApplicationContext
 
 @Log4j
 class AssetPipelineFilter implements Filter {

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
@@ -20,6 +20,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils
 class AssetPipelineFilter implements Filter {
 	AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()
 
+	@Override
 	void init(FilterConfig config) throws ServletException {
 		assetPipelineFilterCore.servletContext = config.servletContext
 		assetPipelineFilterCore.mapping = "assets"
@@ -28,9 +29,11 @@ class AssetPipelineFilter implements Filter {
 		assetPipelineFilterCore.assetPipelineServletResourceRepository = new SpringServletResourceRepository(applicationContext)
 	}
 
+	@Override
 	void destroy() {
 	}
 
+	@Override
 	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		assetPipelineFilterCore.doFilter(request, response, chain)
 	}

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
@@ -23,11 +23,11 @@ class AssetPipelineFilter implements Filter {
 
 
 	@Override
-	void init(FilterConfig config) throws ServletException {
+	void init(final FilterConfig config) throws ServletException {
 		assetPipelineFilterCore.servletContext = config.servletContext
 		assetPipelineFilterCore.mapping = "assets"
 
-		WebApplicationContext applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
+		final WebApplicationContext applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
 		assetPipelineFilterCore.assetPipelineServletResourceRepository = new SpringServletResourceRepository(applicationContext)
 	}
 
@@ -36,7 +36,7 @@ class AssetPipelineFilter implements Filter {
 	}
 
 	@Override
-	void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
 		assetPipelineFilterCore.doFilter(request, response, chain)
 	}
 
@@ -45,18 +45,18 @@ class AssetPipelineFilter implements Filter {
 		private final WebApplicationContext applicationContext
 
 
-		SpringServletResourceRepository(WebApplicationContext applicationContext) {
+		SpringServletResourceRepository(final WebApplicationContext applicationContext) {
 			this.applicationContext = applicationContext
 		}
 
 
 		@Override
-		AssetPipelineServletResource getResource(String path) {
+		AssetPipelineServletResource getResource(final String path) {
 			return SpringServletResource.create(applicationContext.getResource("classpath:assets${path}"))
 		}
 
 		@Override
-		AssetPipelineServletResource getGzippedResource(String path) {
+		AssetPipelineServletResource getGzippedResource(final String path) {
 			return SpringServletResource.create(applicationContext.getResource("assets${path}.gz"))
 		}
 	}
@@ -66,12 +66,12 @@ class AssetPipelineFilter implements Filter {
 		private final Resource resource
 
 
-		private SpringServletResource(Resource resource) {
+		private SpringServletResource(final Resource resource) {
 			this.resource = resource
 		}
 
 
-		static SpringServletResource create(Resource resource) {
+		static SpringServletResource create(final Resource resource) {
 			if(!resource.exists()) {
 				return null
 			}

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
@@ -18,7 +18,9 @@ import org.springframework.web.context.support.WebApplicationContextUtils
 
 @Log4j
 class AssetPipelineFilter implements Filter {
+
 	AssetPipelineFilterCore assetPipelineFilterCore = new AssetPipelineFilterCore()
+
 
 	@Override
 	void init(FilterConfig config) throws ServletException {
@@ -39,10 +41,14 @@ class AssetPipelineFilter implements Filter {
 	}
 
 	private static final class SpringServletResourceRepository implements AssetPipelineServletResourceRepository {
+
 		private final WebApplicationContext applicationContext
+
+
 		SpringServletResourceRepository(WebApplicationContext applicationContext) {
 			this.applicationContext = applicationContext
 		}
+
 
 		@Override
 		AssetPipelineServletResource getResource(String path) {
@@ -56,14 +62,17 @@ class AssetPipelineFilter implements Filter {
 	}
 
 	private static final class SpringServletResource implements AssetPipelineServletResource {
+
 		private final Resource resource
+
 
 		private SpringServletResource(Resource resource) {
 			this.resource = resource
 		}
 
+
 		static SpringServletResource create(Resource resource) {
-			if (!resource.exists()) {
+			if(!resource.exists()) {
 				return null
 			}
 


### PR DESCRIPTION
moved non-Grails instance methods from asset-pipeline-grails AssetProcessorService to static methods in new asset-pipeline-core AssetPaths
This is branched from the simple-cleanup PR, so please merge that first to isolate commits specific to this PR
