### PR TITLE
Replace closure-compile with unshaded artifact

### DIFF
--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	doc         'org.codehaus.groovy:groovy-all:2.4.3'
 	doc         'org.fusesource.jansi:jansi:1.11'
 	compile     'org.mozilla:rhino:1.7R4'
-	compile     'com.google.javascript:closure-compiler:v20160713'
+	compile     'com.google.javascript:closure-compiler-unshaded:v20160713'
 	compile     'commons-logging:commons-logging:1.1.1'
 	//compile   'log4j:log4j:1.2.16'
 	testCompile project(':asset-pipeline-classpath-test')

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	compile 'org.codehaus.groovy:groovy:2.0.7'
 	compile 'org.codehaus.groovy:groovy-templates:2.0.7'
 	compile 'org.mozilla:rhino:1.7R4'
-	compile 'com.google.javascript:closure-compiler:v20160315'
+	compile 'com.google.javascript:closure-compiler-unshaded:v20160315'
 	compile 'commons-logging:commons-logging:1.1.1'
 	testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
 }


### PR DESCRIPTION
Hi.

I faced a problem with using Gson in my Grails project due to pipeline-core plugin. It uses `com.google.javascript:closure-compiler` artifact for some needs, but this artifact shaded with all their libraries (including Gson). This cause large problem in production server - I cannot use new version of Gson (some other libraries affected too) as it loaded from closure-compile jar, which is shipped with shaded old Gson. I suggest replace closure-compile by closure-compile-unshaded for allowance to control dependencies by Gradle and avoid library clashing. Simple and not breakable change.

For older asset-pipeline installation same goal could be achieved with the following buildscript:
```gradle
configurations.all {
  resolutionStrategy {
    dependencySubstitution {
      substitute module('com.google.javascript:closure-compiler:v20160713') with module('com.google.javascript:closure-compiler-unshaded:v20160713')
    }
  }
}
```