### PR TITLE
Ensure that requests for empty paths, like /// don't throw exceptions in Ratpack integration.

### DIFF
--- a/ratpack-asset-pipeline/src/main/java/asset/pipeline/ratpack/internal/AssetPropertiesHandler.java
+++ b/ratpack-asset-pipeline/src/main/java/asset/pipeline/ratpack/internal/AssetPropertiesHandler.java
@@ -72,9 +72,11 @@ public class AssetPropertiesHandler implements Handler {
 
   private static String normalizePath(String path) {
     String[] parts = path.split("/");
-    String fileName = parts[parts.length-1];
-    if (!fileName.contains(".")) {
-      path = path + '/';
+    if (parts.length > 0) {
+      String fileName = parts[parts.length - 1];
+      if (!fileName.contains(".")) {
+        path = path + '/';
+      }
     }
     return path;
   }

--- a/ratpack-asset-pipeline/src/test/groovy/asset.pipeline.ratpack/BaseFunctionalSpec.groovy
+++ b/ratpack-asset-pipeline/src/test/groovy/asset.pipeline.ratpack/BaseFunctionalSpec.groovy
@@ -90,4 +90,20 @@ class BaseFunctionalSpec extends Specification {
     response.statusCode == 404
     response.body.text == "from error handler"
   }
+
+  void "requesting empty urls should not cause server errors"() {
+    expect:
+    statusCodeForExactPath("///") != 500
+  }
+
+  private int statusCodeForExactPath(String path) {
+    def statusLine = new Socket("localhost", address.port).withCloseable { socket ->
+      def pw = new PrintWriter(socket.outputStream)
+      pw.println("GET $path HTTP/1.1")
+      pw.println()
+      pw.flush()
+      new InputStreamReader(socket.inputStream).readLine()
+    }
+    statusLine.tokenize()[1].toInteger()
+  }
 }


### PR DESCRIPTION
This is a fix for #122 which causes us grief in production because it causes exceptions to be thrown which then in turn cause alerts in our monitoring.

Note that I had to resort to using raw sockets for the test because Ratpack's http client normalises requests paths which makes sending requests to paths like `///` impossible.