### PR TITLE
Fix for issue of null BuildSettings.TARGET_DIR on Grails 3.0.x causin…

### DIFF
--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -98,7 +98,9 @@ class AssetPipelineGrailsPlugin extends grails.plugins.Plugin {
 
 
         AssetPipelineConfigHolder.config = assetsConfig
-        AssetPipelineConfigHolder.config.cacheLocation = new File((File) BuildSettings.TARGET_DIR, ".asscache").canonicalPath
+        if (BuildSettings.TARGET_DIR) {
+            AssetPipelineConfigHolder.config.cacheLocation = new File((File) BuildSettings.TARGET_DIR, ".asscache").canonicalPath
+        }
         // Register Link Generator
         String serverURL = config?.getProperty('grails.serverURL', String, null)
         boolean cacheUrls = config?.getProperty('grails.web.linkGenerator.useCache', Boolean, true)


### PR DESCRIPTION
…g groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method java.io.File#<init>

Fixed the error: 
ERROR grails.boot.GrailsApp - Application startup failed
groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method java
.io.File#<init>.
Cannot resolve which method to invoke for [null, class java.lang.String] due to 
overlapping prototypes between:
        [class java.lang.String, class java.lang.String]
        [class java.io.File, class java.lang.String]
        at groovy.lang.MetaClassImpl.chooseMostSpecificParams(MetaClassImpl.java:3241) ~[groovy-2.4.5.jar:2.4.5]

Grails 3.0.17/Linux (Ubuntu 16.10)/ Oracle JDK 1.8.0_101-b13/ Tomcat 8.0.37