### PR TITLE
fix classpath resolver on Windows

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/ClasspathAssetResolver.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/ClasspathAssetResolver.groovy
@@ -14,7 +14,9 @@ import groovy.transform.CompileStatic
 */
 @Commons
 public class ClasspathAssetResolver extends AbstractAssetResolver<URL> {
+    static String NATIVE_FILE_SEPARATOR = File.separator
     static String DIRECTIVE_FILE_SEPARATOR = '/'
+
     ClassLoader classLoader
     String prefixPath
     String assetListPath
@@ -44,7 +46,7 @@ public class ClasspathAssetResolver extends AbstractAssetResolver<URL> {
         if (!relativePath) {
             return null
         }
-        def normalizedPath = AssetHelper.normalizePath(relativePath)
+        def normalizedPath = AssetHelper.normalizePath(relativePath.replace(NATIVE_FILE_SEPARATOR, DIRECTIVE_FILE_SEPARATOR))
         def specs
 
         if (contentType) {


### PR DESCRIPTION
Webjars were not usable by sass-asset-pipeline on Windows because Paths API used in sass-asset-pipeline converted all slashes to backward slashes. This was confusing classpath asset resolver, which works only with forward slashes (and since its fundamental property of classpath asset loader, I fixed it instead of sass-asset-pipeline).
