### PR TITLE
Fix resource path for gzipped Spring Boot assets

### DIFF
--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineFilter.groovy
@@ -57,7 +57,7 @@ class AssetPipelineFilter implements Filter {
 
 		@Override
 		AssetPipelineServletResource getGzippedResource(final String path) {
-			return SpringServletResource.create(applicationContext.getResource("assets${path}.gz"))
+			return SpringServletResource.create(applicationContext.getResource("classpath:assets${path}.gz"))
 		}
 	}
 


### PR DESCRIPTION
Uncompressed assets are looked up in the classpath, but for some reason the gzipped versions are not. I’ve tested this with a run-of-the-mill Spring Boot 1.4.2 setup, and indeed Asset Pipeline does not find the gzipped assets and sends the uncompressed ones instead. With this patch, it sends compressed assets, as expected.