### PR TITLE
Resolving of nested assets in require_tree fails on windows. 

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/JarAssetResolver.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/JarAssetResolver.groovy
@@ -95,7 +95,7 @@ class JarAssetResolver extends AbstractAssetResolver<ZipEntry> {
 			List<String> parentPathArgs = pathArgs ? pathArgs[0..(pathArgs.size() - 1)] as List<String> : [] as List<String>
  			parentPathArgs.addAll(basePathArgs.toList() as List<String>)
 			parentPathArgs = (parentPathArgs).findAll{String it -> it != "."} as List<String>
-			basePath = parentPathArgs.join(File.separator)
+			basePath = parentPathArgs.join(DIRECTIVE_FILE_SEPARATOR)
 		}
 		def combinedPath = basePath ? [prefixPath, basePath].join("/") : prefixPath
 		basePath = AssetHelper.normalizePath(combinedPath) + "/"


### PR DESCRIPTION
Resolving of nested assets in require_tree fails on windows. This is because File.separator was used to join the parentPathArgs together. For a jar this should always be '/'.

So JarAssetResolver was comparing META-INF/assets/required\tree to the jar entries.