### PR TITLE
Clone extensions list to avoid ConcurrentModificationExceptions

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetHelper.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetHelper.groovy
@@ -148,7 +148,7 @@ public class AssetHelper {
         }
 
         String rootName = filename
-        assetFile.extensions.sort(false) { String a, String b -> -(a.size()) <=> -(b.size()) }.each { extension ->
+        assetFile.extensions.toList().sort(false) { String a, String b -> -(a.size()) <=> -(b.size()) }.each { extension ->
             if (filename.endsWith(".${extension}")) {
                 String potentialName = filename.substring(0, filename.lastIndexOf(".${extension}"))
                 if (potentialName.length() < rootName.length()) {


### PR DESCRIPTION
If multiple threads attempt to compile, a ConcurrentModificationException will be thrown (see below).  This fix clones the static list so such a modification won't occur when .sort() is called.

`Caused by: java.util.ConcurrentModificationException
	at java.util.ArrayList.sort(ArrayList.java:1456)
	at java.util.Collections.sort(Collections.java:175)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.sort(DefaultGroovyMethods.java:8476)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.sort(DefaultGroovyMethods.java:8438)
	at org.codehaus.groovy.runtime.dgm$566.invoke(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:274)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at asset.pipeline.AssetHelper.fileNameWithoutExtensionFromArtefact(AssetHelper.groovy:145)
	at asset.pipeline.AssetHelper$fileNameWithoutExtensionFromArtefact$6.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at asset.pipeline.AssetHelper$fileNameWithoutExtensionFromArtefact$6.call(Unknown Source)
	at asset.pipeline.DirectiveProcessor.loadRequiresForTree(DirectiveProcessor.groovy:99)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springsource.loaded.ri.ReflectiveInterceptor.jlrMethodInvoke(ReflectiveInterceptor.java:1426)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:174)
	at asset.pipeline.DirectiveProcessor.loadRequiresForTree(DirectiveProcessor.groovy:93)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springsource.loaded.ri.ReflectiveInterceptor.jlrMethodInvoke(ReflectiveInterceptor.java:1426)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:174)
	at asset.pipeline.DirectiveProcessor.loadRequiresForTree(DirectiveProcessor.groovy:93)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springsource.loaded.ri.ReflectiveInterceptor.jlrMethodInvoke(ReflectiveInterceptor.java:1426)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:174)
	at asset.pipeline.DirectiveProcessor.getFlattenedRequireList(DirectiveProcessor.groovy:76)
	at asset.pipeline.DirectiveProcessor$getFlattenedRequireList.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at asset.pipeline.DirectiveProcessor$getFlattenedRequireList.call(Unknown Source)
	at asset.pipeline.AssetPipeline.getDependencyList(AssetPipeline.groovy:83)
	at asset.pipeline.AssetPipeline$getDependencyList.call(Unknown Source)
	at asset.pipeline.grails.AssetsTagLib$_closure2.doCall(AssetsTagLib.groovy:79)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springsource.loaded.ri.ReflectiveInterceptor.jlrMethodInvoke(ReflectiveInterceptor.java:1426)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1210)
	at groovy.lang.ExpandoMetaClass.invokeMethod(ExpandoMetaClass.java:1123)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1019)
	at groovy.lang.Closure.call(Closure.java:426)
	at asset.pipeline.grails.AssetsTagLib$_closure2.call(AssetsTagLib.groovy)
	at org.codehaus.groovy.grails.web.pages.GroovyPage.invokeTagLibClosure(GroovyPage.java:494)
	at org.codehaus.groovy.grails.web.pages.GroovyPage.invokeTag(GroovyPage.java:419)`