### PR TITLE
fix misused method

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/FileSystemAssetResolver.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/FileSystemAssetResolver.groovy
@@ -62,7 +62,7 @@ class FileSystemAssetResolver extends AbstractAssetResolver<File> {
 		if(!relativePath) {
 			return null
 		}
-		relativePath = relativePath.replace(QUOTED_FILE_SEPARATOR,DIRECTIVE_FILE_SEPARATOR)
+		relativePath = relativePath.replaceAll(QUOTED_FILE_SEPARATOR,DIRECTIVE_FILE_SEPARATOR)
 		def specs
 		if(contentType) {
 			specs = AssetHelper.getPossibleFileSpecs(contentType)


### PR DESCRIPTION
`QUOTED_FILE_SEPARATOR` is a regex pattern. But `replace` only works for `String`.
`replaceAll` is the right.