### PR TITLE
Add feature for deduplicating javascript and stylesheets

### DIFF
--- a/asset-pipeline-grails/grails-app/assets/javascripts/asset-pipeline/test/test_simple_require.js
+++ b/asset-pipeline-grails/grails-app/assets/javascripts/asset-pipeline/test/test_simple_require.js
@@ -1,0 +1,3 @@
+//=require libs/file_a
+
+console.log("This and file_a should be included");

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetMethodTagLib.groovy
@@ -16,16 +16,19 @@ class AssetMethodTagLib {
 	def assetPath = {final def attrs ->
 		final def     src
 		final UrlBase urlBase
+		final boolean useManifest
 
 		if (attrs instanceof Map) {
-			src     = attrs.src
-			urlBase = attrs.absolute ? SERVER_BASE_URL : CONTEXT_PATH
+			src         = attrs.src
+			urlBase     = attrs.absolute ? SERVER_BASE_URL : CONTEXT_PATH
+			useManifest = attrs.useManifest ?: true
 		}
 		else {
-			src     = attrs
-			urlBase = CONTEXT_PATH
+			src         = attrs
+			urlBase     = CONTEXT_PATH
+            useManifest = true
 		}
 
-		return assetProcessorService.assetBaseUrl(request, urlBase) + assetProcessorService.getAssetPath(Objects.toString(src))
+		return assetProcessorService.assetBaseUrl(request, urlBase) + assetProcessorService.getAssetPath(Objects.toString(src), useManifest)
 	}
 }

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -26,11 +26,11 @@ class AssetsTagLib {
 	def javascript = {final attrs ->
 		final GrailsPrintWriter outPw = out
 		attrs.remove('href')
-		element(attrs, 'js', 'application/javascript', null) {final String src, final String queryString, final outputAttrs, final String endOfLine ->
+		element(attrs, 'js', 'application/javascript', null) {final String src, final String queryString, final outputAttrs, final String endOfLine, final boolean useManifest ->
 			if(attrs.containsKey('asset-defer')) {
-				script(outputAttrs + [type: "text/javascript", src: assetPath(src: src) + queryString],'')
+				script(outputAttrs + [type: "text/javascript", src: assetPath(src: src, useManifest: useManifest) + queryString],'')
 			} else {
-				outPw << '<script type="text/javascript" src="' << assetPath(src: src) << queryString << '" ' << paramsToHtmlAttr(outputAttrs) << '></script>' << endOfLine
+				outPw << '<script type="text/javascript" src="' << assetPath(src: src, useManifest: useManifest) << queryString << '" ' << paramsToHtmlAttr(outputAttrs) << '></script>' << endOfLine
 			}
 
 		}
@@ -45,12 +45,10 @@ class AssetsTagLib {
 	 */
 	def stylesheet = {final attrs ->
 		final GrailsPrintWriter outPw = out
-		element(attrs, 'css', 'text/css', Objects.toString(attrs.remove('href'), null)) {final String src, final String queryString, final outputAttrs, final String endOfLine ->
+		element(attrs, 'css', 'text/css', Objects.toString(attrs.remove('href'), null)) {final String src, final String queryString, final outputAttrs, final String endOfLine, final boolean useManifest ->
+			outPw << '<link rel="stylesheet" href="' << assetPath(src: src, useManifest: useManifest) << queryString << '" ' << paramsToHtmlAttr(outputAttrs) << '/>'
 			if (endOfLine) {
-				outPw << '<link rel="stylesheet" href="' << assetPath(src: src) << queryString << '" ' << paramsToHtmlAttr(outputAttrs) << '/>' << endOfLine
-			}
-			else {
-				outPw << link([rel: 'stylesheet', href: src] + outputAttrs)
+				outPw << endOfLine
 			}
 		}
 	}
@@ -100,14 +98,16 @@ class AssetsTagLib {
 			if (uniqMode && isIncluded(name)) {
 				return
 			}
+			def useManifest = !nonBundledMode
+
 			AssetPipeline.getDependencyList(uri, contentType, extension)?.each {
 				if (uniqMode) {
 					def path = nameAndExtension(it.path, ext)
 					if (path.uri == uri || !isIncluded(path)) {
-						output(it.path, queryString, attrs, LINE_BREAK)
+						output(it.path, queryString, attrs, LINE_BREAK, useManifest)
 					}
 				} else {
-					output(it.path, queryString, attrs, LINE_BREAK)
+					output(it.path, queryString, attrs, LINE_BREAK, useManifest)
 				}
 			}
 		}

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -55,7 +55,7 @@ class AssetsTagLib {
 		}
 	}
 
-	private boolean isIncluded(String path) {
+	private boolean isIncluded(def path) {
 		HashSet<String> memo = request."$ASSET_REQUEST_MEMO"
 		if (memo == null) {
 			memo = new HashSet<String>()
@@ -64,7 +64,7 @@ class AssetsTagLib {
 		!memo.add(path)
 	}
 
-	private def nameAndExtension(String src, String ext) {
+	private static def nameAndExtension(String src, String ext) {
 		int lastDotIndex = src.lastIndexOf('.')
 		if (lastDotIndex >= 0) {
 			[uri: src.substring(0, lastDotIndex), extension: src.substring(lastDotIndex + 1)]
@@ -97,13 +97,13 @@ class AssetsTagLib {
 				attrs.charset \
 					? "?compile=false&encoding=${attrs.charset}"
 					: '?compile=false'
-			if (uniqMode && isIncluded(uri)) {
+			if (uniqMode && isIncluded(name)) {
 				return
 			}
 			AssetPipeline.getDependencyList(uri, contentType, extension)?.each {
 				if (uniqMode) {
-					def path = nameAndExtension(it.path, ext).uri
-					if (path == uri || !isIncluded(path)) {
+					def path = nameAndExtension(it.path, ext)
+					if (path.uri == uri || !isIncluded(path)) {
 						output(it.path, queryString, attrs, LINE_BREAK)
 					}
 				} else {

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -84,7 +84,7 @@ class AssetsTagLib {
 		final def nonBundledMode = uniqMode || (!AssetPipelineConfigHolder.manifest && conf.bundle != true && attrs.remove('bundle') != 'true')
 		
 		if (! nonBundledMode) {
-			output(src, '', attrs, '')
+			output(src, '', attrs, '', true)
 		}
 		else {
 			def name = nameAndExtension(src, ext)

--- a/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
+++ b/asset-pipeline-grails/grails-app/taglib/asset/pipeline/grails/AssetsTagLib.groovy
@@ -79,9 +79,7 @@ class AssetsTagLib {
 			src = srcOverride
 		}
 		def uniqMode = attrs.remove('uniq') != null
-		if (uniqMode && isIncluded(src)) {
-			return
-		}
+
 		src = "${AssetHelper.nameWithoutExtension(src)}.${ext}"
 		def conf = grailsApplication.config.grails.assets
 
@@ -99,8 +97,16 @@ class AssetsTagLib {
 				attrs.charset \
 					? "?compile=false&encoding=${attrs.charset}"
 					: '?compile=false'
+			if (uniqMode && isIncluded(uri)) {
+				return
+			}
 			AssetPipeline.getDependencyList(uri, contentType, extension)?.each {
-				if (nameAndExtension(it.path, ext).uri == uri || !isIncluded(it.path)) {
+				if (uniqMode) {
+					def path = nameAndExtension(it.path, ext).uri
+					if (path == uri || !isIncluded(path)) {
+						output(it.path, queryString, attrs, LINE_BREAK)
+					}
+				} else {
 					output(it.path, queryString, attrs, LINE_BREAK)
 				}
 			}

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -89,7 +89,10 @@ class AssetPipelineGrailsPlugin extends grails.plugins.Plugin {
                 log.warn "Unable to find asset-pipeline manifest, etags will not be properly generated"
             }
         }
-        if(manifestFile?.exists()) {
+
+        def useManifest = assetsConfig.useManifest ?: true
+
+        if(useManifest && manifestFile?.exists()) {
             try {
                 manifestProps.load(manifestFile.inputStream)
                 assetsConfig.manifest = manifestProps

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetProcessorService.groovy
@@ -46,10 +46,17 @@ class AssetProcessorService {
 		return mapping
 	}
 
+	String getAssetPath(final String path, final boolean useManifest) {
+		getAssetPath(path, grailsApplication.config.grails.assets as ConfigObject, useManifest)
+	}
 
-	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets) {
+	String getAssetPath(final String path, final ConfigObject conf = grailsApplication.config.grails.assets, final boolean useManifest = true) {
 		final String relativePath = trimLeadingSlash(path)
-		return manifest?.getProperty(relativePath) ?: relativePath
+		if (useManifest) {
+			return manifest?.getProperty(relativePath) ?: relativePath
+		} else {
+			return relativePath
+		}
 	}
 
 

--- a/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -89,6 +89,18 @@ class AssetsTagLibSpec extends Specification {
 			output == '<script type="text/javascript" src="/assets/asset-pipeline/test/test.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/file_a.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/file_c.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/file_b.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/subset/subset_a.js?compile=false" ></script>' + LINE_BREAK
 	}
 
+	void "should not return javascript link twice in uniq mode"() {
+		given:
+			final def assetSrc = "asset-pipeline/test/test_simple_require.js"
+			final def depAssetSrc = "asset-pipeline/test/libs/file_a.js"
+		expect:
+			tagLib.javascript(src: assetSrc, uniq: true) == '<script type="text/javascript" src="/assets/asset-pipeline/test/libs/file_a.js?compile=false" ></script>' + LINE_BREAK + '<script type="text/javascript" src="/assets/asset-pipeline/test/test_simple_require.js?compile=false" ></script>' + LINE_BREAK
+			tagLib.javascript(src: assetSrc, uniq: true) == ''
+			tagLib.javascript(src: depAssetSrc, uniq: true) == ''
+		cleanup:
+			request."${AssetsTagLib.ASSET_REQUEST_MEMO}" = null
+	}
+
 	void "should return stylesheet link tag when debugMode is off"() {
 		given:
 			grailsApplication.config.grails.assets.bundle = true
@@ -119,6 +131,18 @@ class AssetsTagLibSpec extends Specification {
 			output = tagLib.stylesheet(src: assetSrc)
 		then:
 			output == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css?compile=false" />' + LINE_BREAK + '<link rel="stylesheet" href="/assets/asset-pipeline/test/test2.css?compile=false" />' + LINE_BREAK
+	}
+
+	void "should not return stylesheet link twice in uniq mode"() {
+		given:
+			final def assetSrc = "asset-pipeline/test/test.css"
+			final def depAssetSrc = "asset-pipeline/test/test2.css"
+		expect:
+			tagLib.stylesheet(src: assetSrc, uniq: true) == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css?compile=false" />' + LINE_BREAK + '<link rel="stylesheet" href="/assets/asset-pipeline/test/test2.css?compile=false" />' + LINE_BREAK
+			tagLib.stylesheet(src: depAssetSrc, uniq: true) == ''
+			tagLib.stylesheet(src: assetSrc, uniq: true) == ''
+		cleanup:
+			request."${AssetsTagLib.ASSET_REQUEST_MEMO}" = null
 	}
 
 	void "should return image tag"() {

--- a/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -15,13 +15,10 @@
  */
 package asset.pipeline.grails
 
-
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.fs.FileSystemAssetResolver
 import grails.test.mixin.TestFor
 import spock.lang.Specification
-
-
 
 /**
  * @author David Estes

--- a/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -113,7 +113,7 @@ class AssetsTagLibSpec extends Specification {
 			grailsApplication.config.grails.assets.bundle = true
 			final def assetSrc = "asset-pipeline/test/test.css"
 		expect:
-			tagLib.stylesheet(href: assetSrc) == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css"/>'
+			tagLib.stylesheet(href: assetSrc) == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css" />'
 	}
 
 	void "should always return stylesheet link tag when bundle attr is 'true'"() {
@@ -123,7 +123,7 @@ class AssetsTagLibSpec extends Specification {
 			params."_debugAssets" = "y"
 			final def assetSrc = "asset-pipeline/test/test.css"
 		expect:
-			tagLib.stylesheet(href: assetSrc, bundle: 'true') == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css"/>'
+			tagLib.stylesheet(href: assetSrc, bundle: 'true') == '<link rel="stylesheet" href="/assets/asset-pipeline/test/test.css" />'
 	}
 
 	void "should return stylesheet link tag with seperated files when debugMode is on"() {

--- a/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
+++ b/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetsTagLibSpec.groovy
@@ -98,6 +98,16 @@ class AssetsTagLibSpec extends Specification {
 			request."${AssetsTagLib.ASSET_REQUEST_MEMO}" = null
 	}
 
+	void "should return javascript and stylesheets of the same basename"() {
+		given:
+			final def jsAssetSrc = "asset-pipeline/test/test.js"
+			final def cssAssetSrc = "asset-pipeline/test/test.css"
+		expect:
+			tagLib.javascript(src: jsAssetSrc, uniq: true) != ''
+			tagLib.javascript(src: jsAssetSrc, uniq: true) == ''
+			tagLib.stylesheet(src: cssAssetSrc, uniq: true) != ''
+	}
+
 	void "should return stylesheet link tag when debugMode is off"() {
 		given:
 			grailsApplication.config.grails.assets.bundle = true


### PR DESCRIPTION
This adds an option to the asset tags in GSP called "uniq" which will deduplicate dependencies on a page. It is technically available on all of the asset tags, but is probably only useful for the javascript and stylesheet.

The idea here is that if you have javascript files A and B, both of which require file C, we don't want to write out a script tag for C twice, or have C included in two different bundles. Because this would make pre-bundling assets basically impossible, using the uniq="true" option disables bundling and will write out script/link tags for each dependency, but only once per page.

My use case for this is that my application's main page is broken into a bunch of different modules. These modules may or may not be included depending on the capabilities of the user that's logged in. This change lets each module declare its own dependencies without having to worry about the dependencies that other modules declare. 

I'd be happy to help update docs if this change is accepted.