### PR TITLE
Finding "custom" .properties files in Grails i18n -plugin

### DIFF
--- a/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nProcessor.groovy
+++ b/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nProcessor.groovy
@@ -111,7 +111,7 @@ class I18nProcessor extends AbstractProcessor {
             if (m.group(2)){
                 def locales = m.group(2).split('_')
                 
-                def sb = new StringBuffer('messages')
+                def sb = new StringBuffer(baseFile)
                 for(locale in locales){
                     if(locale.empty){
                         options << sb.toString()

--- a/i18n-asset-pipeline-grails/src/test/groovy/asset/pipeline/i18n/I18nProcessorSpec.groovy
+++ b/i18n-asset-pipeline-grails/src/test/groovy/asset/pipeline/i18n/I18nProcessorSpec.groovy
@@ -78,13 +78,13 @@ special.quotationMarks = This is a "test".
 
         and: 'a mocked resource loader'
         ResourceLoader resourceLoader = Mock()
-        1 * resourceLoader.getResource('messages_de.properties') >> nonExistantResource
-        1 * resourceLoader.getResource('messages_de.xml') >> nonExistantResource
-        1 * resourceLoader.getResource('file:grails-app/i18n/messages_de.properties') >>
+        1 * resourceLoader.getResource('mymessages_de.properties') >> nonExistantResource
+        1 * resourceLoader.getResource('mymessages_de.xml') >> nonExistantResource
+        1 * resourceLoader.getResource('file:grails-app/i18n/mymessages_de.properties') >>
             new InputStreamResource(
                 new ByteArrayInputStream(MESSAGES.bytes)
             )
-        0 * resourceLoader.getResource('file:grails-app/i18n/messages_de.xml')
+        0 * resourceLoader.getResource('file:grails-app/i18n/mymessages_de.xml')
         processor.resourceLoader = resourceLoader
 
         and: 'a localized mock asset file'


### PR DESCRIPTION
Existing code could not find correct properties file if locale was given. It was hard coded as "messages". This PR adds support for that.