### PR TITLE
Support for multiple anonymous javascript functions in Grails i18n plugin

### DIFF
--- a/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nProcessor.groovy
+++ b/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nProcessor.groovy
@@ -187,7 +187,7 @@ class I18nProcessor extends AbstractProcessor {
 
     if (typeof win.$L === 'function' && typeof win.$L.messages !== 'undefined') {
 
-        var copy = function(destination, source) {
+        var merge = function(destination, source) {
             for (var property in source) {
                 if (source.hasOwnProperty(property)) {
                     destination[property] = source[property];
@@ -196,7 +196,7 @@ class I18nProcessor extends AbstractProcessor {
             return destination;
         };
 
-         messages = copy(messages, win.$L.messages)
+        messages = merge(messages, win.$L.messages)
     }
 
     var getMessage = function (code) {

--- a/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nProcessor.groovy
+++ b/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nProcessor.groovy
@@ -196,7 +196,7 @@ class I18nProcessor extends AbstractProcessor {
             return destination;
         };
 
-        messages = merge(messages, win.$L.messages)
+        messages = merge(messages, win.$L.messages);
     }
 
     var getMessage = function (code) {

--- a/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nProcessor.groovy
+++ b/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nProcessor.groovy
@@ -185,9 +185,27 @@ class I18nProcessor extends AbstractProcessor {
         buf << '''
     }
 
-    win.$L = function (code) {
-        return messages[code];
+    if (typeof win.$L === 'function' && typeof win.$L.messages !== 'undefined') {
+
+        var copy = function(destination, source) {
+            for (var property in source) {
+                if (source.hasOwnProperty(property)) {
+                    destination[property] = source[property];
+                }
+            }
+            return destination;
+        };
+
+         messages = copy(messages, win.$L.messages)
     }
+
+    var getMessage = function (code) {
+        return messages[code];
+    };
+
+    getMessage.messages = messages;
+
+    win.$L = getMessage;
 }(this));
 '''
         buf.toString()

--- a/i18n-asset-pipeline-grails/src/test/groovy/asset/pipeline/i18n/I18nProcessorSpec.groovy
+++ b/i18n-asset-pipeline-grails/src/test/groovy/asset/pipeline/i18n/I18nProcessorSpec.groovy
@@ -155,9 +155,27 @@ special.crlf''',
         buf << '''
     }
 
-    win.$L = function (code) {
-        return messages[code];
+    if (typeof win.$L === 'function' && typeof win.$L.messages !== 'undefined') {
+
+        var merge = function(destination, source) {
+            for (var property in source) {
+                if (source.hasOwnProperty(property)) {
+                    destination[property] = source[property];
+                }
+            }
+            return destination;
+        };
+
+        messages = merge(messages, win.$L.messages);
     }
+
+    var getMessage = function (code) {
+        return messages[code];
+    };
+
+    getMessage.messages = messages;
+
+    win.$L = getMessage;
 }(this));
 '''
 


### PR DESCRIPTION
Added support for multiple anonymous functions in the page.

Use case is that I want to have translations in multiple properties files and also have plugins to contain their own javascript translations in the plugin.

So I can have multiple calls to taglib in the page for example:

<asset:i18n name="foo" locale="${lang}"/>
<asset:i18n name="plugin/bar locale="${lang}"/>

Current implementation does not support this.

I just exposed messages through $L.messages and then merge the associative arrays.
This should be also very compatible with different browsers because only thing that is used is "hasOwnProperty"

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty

If ES6 is ok the the merge function could be replaced with Object.assign()

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign