### PR TITLE
Support importing .sass files

### DIFF
--- a/sass-asset-pipeline/src/main/groovy/asset/pipeline/jsass/SassAssetFileImporter.groovy
+++ b/sass-asset-pipeline/src/main/groovy/asset/pipeline/jsass/SassAssetFileImporter.groovy
@@ -47,7 +47,11 @@ class SassAssetFileImporter implements Importer {
         Path parentPath = Paths.get(parent)
         Path relativeRootPath = parentPath.parent ?: Paths.get('.')
         Path importUrlPath = Paths.get(importUrl)
-        def possibleStylesheets = [relativeRootPath.resolve("${importUrlPath}.scss").toString(), relativeRootPath.resolve("${importUrlPath.parent ? importUrlPath.parent.toString() + '/' : ''}_${importUrlPath.fileName}.scss").toString(), "${importUrlPath.fileName}.scss","_${importUrlPath.fileName}.scss" ]
+        def possibleStylesheets = SassAssetFile.extensions.collectMany { extension ->
+            [relativeRootPath.resolve("${importUrlPath}.${extension}").toString(),
+            relativeRootPath.resolve("${importUrlPath.parent ? importUrlPath.parent.toString() + '/' : ''}_${importUrlPath.fileName}.${extension}").toString(),
+            "${importUrlPath.fileName}.${extension}","_${importUrlPath.fileName}.${extension}"]
+        }
         
         for (String stylesheetPath : possibleStylesheets) {
             String standardPathStyle = stylesheetPath?.replaceAll(QUOTED_FILE_SEPARATOR, DIRECTIVE_FILE_SEPARATOR)


### PR DESCRIPTION
I was trying to import .sass files (Bulma framework) and found that the pipeline was hard-coded to only follow `.scss` `@import`s in the stylesheets. This PR should hopefully fix that. I'm not very well-versed in Grails and Groovy, and couldn't locally try out this fix (the tests all still pass), so proceed with caution.