### PR TITLE
Improved hashing of assets

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -74,6 +74,10 @@ assets {
   // Can add custom asset locations (directories or individual jar files)
   from '/vendor/lib'
   from '/path/to/file.jar'
+  
+  // can be used to customize the hashing of the assets
+  digestAlgorithm = 'MD5'
+  digestSalt = ''
 }
 
 dependencies {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetHelper.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetHelper.groovy
@@ -210,10 +210,9 @@ public class AssetHelper {
      * @return md5 String
      */
     static String getByteDigest(byte[] fileBytes) {
-        def hashConfig = AssetPipelineConfigHolder.getConfig()?.url?.hash
 
-        def hashAlgorithm = hashConfig?.algorithm ?: 'MD5' as String
-        def salt = hashConfig?.salt ?: '' as String
+        def hashAlgorithm = AssetPipelineConfigHolder.getConfig()?.digestAlgorithm ?: 'MD5'
+        def salt = AssetPipelineConfigHolder.getConfig()?.digestSalt ?: ''
 
         // Generate Checksum based on the file contents and the configuration settings
         MessageDigest md = MessageDigest.getInstance(hashAlgorithm)
@@ -230,6 +229,7 @@ public class AssetHelper {
         md.update(hashBytes)
         return md.digest().encodeHex().toString()
     }
+
 
     /**
      * Normalizes a path into a standard path, stripping out all path elements that walk the path (i.e. '..' and '.')


### PR DESCRIPTION
We discovered that sometimes under certain circumstances an invalid object was stored in the cache (possibly a File.exists() returned a false due to high load despite the presence of the file), which then led to NullPointerExceptions and empty assets. Furthermore, this invalid object did not disappear from the cache.

This PR improves the `AssetHelper.getByteDigest(byte[] fileBytes)` method to make the hashing algorithm and an additional salt configurable.