### PR TITLE
Change logging in the less asset pipeline plugin to reference slf4j

### DIFF
--- a/less-asset-pipeline/build.gradle
+++ b/less-asset-pipeline/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     provided 'org.codehaus.groovy:groovy-all:2.0.7'
     compile project(':asset-pipeline-core')
     compile 'org.mozilla:rhino:1.7R4'
-    compile 'log4j:log4j:1.2.17'
+    compile 'org.slf4j:slf4j-api:1.7.28'
     compile "com.github.sommeri:less4j:1.17.2"
     compile "com.github.sommeri:less4j-javascript:0.0.1"
 

--- a/less-asset-pipeline/src/main/groovy/asset/pipeline/less/AssetPipelineLessSource.groovy
+++ b/less-asset-pipeline/src/main/groovy/asset/pipeline/less/AssetPipelineLessSource.groovy
@@ -1,31 +1,14 @@
 package asset.pipeline.less
 
 import com.github.sommeri.less4j.*
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.ArrayList;
-import java.util.Collection;
+import groovy.util.logging.Slf4j
+
 import asset.pipeline.CacheManager
 import asset.pipeline.AssetHelper
-import asset.pipeline.AssetPipelineConfigHolder
-import asset.pipeline.AssetFile
 import asset.pipeline.AssetCompiler
 import asset.pipeline.processors.CssProcessor
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import groovy.util.logging.Commons
 
-
-@Commons
+@Slf4j
 class AssetPipelineLessSource extends LessSource {
 	def sourceFile
 	String contents

--- a/less-asset-pipeline/src/main/groovy/asset/pipeline/less/Less4jProcessor.groovy
+++ b/less-asset-pipeline/src/main/groovy/asset/pipeline/less/Less4jProcessor.groovy
@@ -1,16 +1,14 @@
 package asset.pipeline.less
 
-import asset.pipeline.AssetHelper
 import com.github.sommeri.less4j.LessCompiler
 import com.github.sommeri.less4j.core.ThreadUnsafeLessCompiler
 import com.github.sommeri.less4j_javascript.Less4jJavascript
-import groovy.util.logging.Log4j
 import asset.pipeline.AbstractProcessor
-import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
 import com.github.sommeri.less4j.Less4jException
+import groovy.util.logging.Slf4j
 
-@Log4j
+@Slf4j
 class Less4jProcessor extends AbstractProcessor {
 
     Less4jProcessor(precompiler) {

--- a/less-asset-pipeline/src/main/groovy/asset/pipeline/less/LessAssetFile.groovy
+++ b/less-asset-pipeline/src/main/groovy/asset/pipeline/less/LessAssetFile.groovy
@@ -2,7 +2,6 @@ package asset.pipeline.less
 
 import asset.pipeline.AbstractAssetFile
 import asset.pipeline.AssetCompiler
-import asset.pipeline.AssetHelper
 import asset.pipeline.CacheManager
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.processors.CssProcessor

--- a/less-asset-pipeline/src/main/groovy/asset/pipeline/less/LessProcessor.groovy
+++ b/less-asset-pipeline/src/main/groovy/asset/pipeline/less/LessProcessor.groovy
@@ -5,8 +5,8 @@ import asset.pipeline.CacheManager
 import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
-import groovy.util.logging.Commons
 import asset.pipeline.processors.CssProcessor
+import groovy.util.logging.Slf4j
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.JavaScriptException
 import org.mozilla.javascript.NativeArray
@@ -14,7 +14,7 @@ import org.mozilla.javascript.NativeObject
 import org.mozilla.javascript.Scriptable
 import sun.net.www.protocol.asset.Handler
 
-@Commons
+@Slf4j
 class LessProcessor extends AbstractProcessor {
     public static final java.lang.ThreadLocal threadLocal   = new ThreadLocal();
     public static final java.lang.ThreadLocal localCompiler = new ThreadLocal();


### PR DESCRIPTION
This change will allow projects that use this plugin to use their own choice of logging implementation rather than bringing in a transitive dependency on a logging framework they may not use.