### PR TITLE
Change logging to use slf4j in sass-asset-pipeline project.

### DIFF
--- a/sass-asset-pipeline/build.gradle
+++ b/sass-asset-pipeline/build.gradle
@@ -44,7 +44,7 @@ sourceSets {
 dependencies {
     provided 'org.codehaus.groovy:groovy-all:2.0.5'
 	compile project(':asset-pipeline-core')
-    compile 'log4j:log4j:1.2.17'
+    compile 'org.slf4j:slf4j-api:1.7.28'
     compile 'io.bit3:jsass:5.7.3'
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
     testRuntime 'org.slf4j:slf4j-simple:1.7.21'

--- a/sass-asset-pipeline/src/main/groovy/asset/pipeline/jsass/SassAssetFileImporter.groovy
+++ b/sass-asset-pipeline/src/main/groovy/asset/pipeline/jsass/SassAssetFileImporter.groovy
@@ -16,17 +16,18 @@
 package asset.pipeline.jsass
 
 import asset.pipeline.AssetFile
+import groovy.util.logging.Slf4j
+
 import java.util.regex.Pattern
 import asset.pipeline.AssetHelper
 import asset.pipeline.CacheManager
-import groovy.util.logging.Commons
 import io.bit3.jsass.importer.Import
 import io.bit3.jsass.importer.Importer
 
 import java.nio.file.Path
 import java.nio.file.Paths
 
-@Commons
+@Slf4j
 class SassAssetFileImporter implements Importer {
     AssetFile baseFile
     static String QUOTED_FILE_SEPARATOR = Pattern.quote(File.separator)

--- a/sass-asset-pipeline/src/main/groovy/asset/pipeline/jsass/SassProcessor.groovy
+++ b/sass-asset-pipeline/src/main/groovy/asset/pipeline/jsass/SassProcessor.groovy
@@ -19,12 +19,12 @@ import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
 import asset.pipeline.AssetPipelineConfigHolder
-import groovy.util.logging.Commons
+import groovy.util.logging.Slf4j
 import io.bit3.jsass.Compiler
 import io.bit3.jsass.Options
 import io.bit3.jsass.OutputStyle
 
-@Commons
+@Slf4j
 class SassProcessor extends AbstractProcessor {
     final Compiler compiler = new Compiler();
     final Options options = new Options();


### PR DESCRIPTION
This change will allow projects that use this plugin to use their own choice of logging implementation rather than bringing in a transitive dependency on a logging framework they may not use.