### PR TITLE
Use slf4j for logging in asset-pipeline-core.

### DIFF
--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -58,10 +58,11 @@ dependencies {
 	doc         'org.fusesource.jansi:jansi:1.11'
 	compile     'org.mozilla:rhino:1.7R4'
 	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20180716'
-	compile     'commons-logging:commons-logging:1.1.1'
+	compile 'org.slf4j:slf4j-api:1.7.28'
 	//compile   'log4j:log4j:1.2.16'
 	testCompile project(':asset-pipeline-classpath-test')
 	testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
+	testRuntime 'org.slf4j:slf4j-simple:1.7.28'
 }
 
 publishing {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetCompiler.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetCompiler.groovy
@@ -15,17 +15,15 @@
  */
 package asset.pipeline
 
-import groovy.util.logging.Commons
 import asset.pipeline.processors.ClosureCompilerProcessor
 import asset.pipeline.utils.MultiOutputStream
 import asset.pipeline.processors.CssMinifyPostProcessor
+import groovy.util.logging.Slf4j
+
 import java.util.zip.GZIPOutputStream
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.Future
 import java.util.concurrent.ExecutorCompletionService
 import java.util.concurrent.CompletionService
 
@@ -37,7 +35,7 @@ import java.util.concurrent.CompletionService
  * @author David Estes
  * @author Graeme Rocher
  */
-@Commons
+@Slf4j
 class AssetCompiler {
 	def includeRules = [:]
 	def excludeRules = [:]

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetSpecLoader.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetSpecLoader.groovy
@@ -1,6 +1,6 @@
 package asset.pipeline
 
-import groovy.util.logging.Commons
+import groovy.util.logging.Slf4j
 
 /*
  * Copyright 2014 original authors
@@ -30,7 +30,7 @@ import groovy.util.logging.Commons
  *
  * @author Graeme Rocher
  */
-@Commons
+@Slf4j
 class AssetSpecLoader {
 
     static final String FACTORIES_RESOURCE_LOCATION = "META-INF/asset-pipeline/asset.specs"

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/DirectiveProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/DirectiveProcessor.groovy
@@ -15,9 +15,7 @@
 */
 package asset.pipeline
 
-import groovy.util.logging.Commons
-
-import java.nio.charset.Charset
+import groovy.util.logging.Slf4j
 import groovy.transform.CompileStatic
 
 /**
@@ -27,7 +25,7 @@ import groovy.transform.CompileStatic
  *
  * @author David Estes
  */
-@Commons
+@Slf4j
 class DirectiveProcessor {
 
     /**

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/ClasspathAssetResolver.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/ClasspathAssetResolver.groovy
@@ -3,8 +3,8 @@ package asset.pipeline.fs
 import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
 import asset.pipeline.GenericAssetFile
-import groovy.util.logging.Commons
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 
 /**
 * Implementation of the {@link AssetResolver} interface for resolving files on the classpath.
@@ -12,7 +12,7 @@ import groovy.transform.CompileStatic
 *
 * @author David Estes
 */
-@Commons
+@Slf4j
 public class ClasspathAssetResolver extends AbstractAssetResolver<URL> {
     static String NATIVE_FILE_SEPARATOR = File.separator
     static String DIRECTIVE_FILE_SEPARATOR = '/'

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/FileSystemAssetResolver.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/FileSystemAssetResolver.groovy
@@ -18,8 +18,8 @@ package asset.pipeline.fs
 
 import asset.pipeline.*
 import groovy.transform.CompileStatic
-import groovy.util.logging.Commons
-import java.io.BufferedInputStream
+import groovy.util.logging.Slf4j
+
 import java.util.regex.Pattern
 import java.nio.file.LinkOption
 
@@ -31,7 +31,7 @@ import java.nio.file.LinkOption
  * @author Graeme Rocher
  */
 
-@Commons
+@Slf4j
 class FileSystemAssetResolver extends AbstractAssetResolver<File> {
 	static String QUOTED_FILE_SEPARATOR = Pattern.quote(File.separator)
 	static String DIRECTIVE_FILE_SEPARATOR = '/'

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/JarAssetResolver.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/JarAssetResolver.groovy
@@ -18,14 +18,13 @@ package asset.pipeline.fs
 
 import asset.pipeline.*
 import groovy.transform.CompileStatic
-import groovy.util.logging.Commons
+import groovy.util.logging.Slf4j
 
 import java.util.jar.JarEntry
 import java.util.regex.Pattern
 import java.util.jar.JarFile
 import java.util.zip.ZipEntry
 import java.util.zip.ZipException
-import java.io.BufferedInputStream
 
 /**
  * Implementation of the {@link AssetResolver} interface for resolving from JAR files or ZIP files
@@ -33,7 +32,7 @@ import java.io.BufferedInputStream
  * @author David Estes
  * @author Graeme Rocher
  */
-@Commons
+@Slf4j
 class JarAssetResolver extends AbstractAssetResolver<ZipEntry> {
 	static String QUOTED_FILE_SEPARATOR = Pattern.quote("/")
 	static String DIRECTIVE_FILE_SEPARATOR = '/'

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/BabelJsProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/BabelJsProcessor.groovy
@@ -17,11 +17,12 @@
 package asset.pipeline.processors
 
 import asset.pipeline.AssetFile
-import groovy.util.logging.Commons
 import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.JsAssetFile
 import asset.pipeline.AssetPipelineConfigHolder
+import groovy.util.logging.Slf4j
+
 import javax.script.Invocable
 import javax.script.ScriptEngine
 import javax.script.ScriptEngineManager
@@ -30,7 +31,7 @@ import javax.script.SimpleBindings
 // CoffeeScript engine will attempt to use Node.JS coffee if it is available on
 // the system path. If not, it uses Mozilla Rhino to compile the CoffeeScript
 // template using the javascript in-browser compiler.
-@Commons
+@Slf4j
 class BabelJsProcessor extends AbstractProcessor {
 
 	static Boolean NODE_SUPPORTED


### PR DESCRIPTION
Use slf4j in asset-pipeline-core to avoid transitive dependency on a specific logging framework.