### PR TITLE
Document minifyOptions.excludes

### DIFF
--- a/asset-pipeline-docs/src/asciidoc/gradle/configuration.adoc
+++ b/asset-pipeline-docs/src/asciidoc/gradle/configuration.adoc
@@ -15,6 +15,7 @@ assets {
   minifyOptions = [
     optimizationLevel: 'SIMPLE',
     angularPass: true // Can use @ngInject annotation for Angular Apps
+    excludes: ['**/bundle.js'] // Example of excluding specific resources from minification, e.g., if it was minified externally
   ]
 
   includes = []


### PR DESCRIPTION
Add example for minifyOptions.excludes.

For projects that are based on the react-webpack profile, a bundle.js is outputted and is already minified. Asset-pipeline handles this by excluding bundle.js from the minification, but there was no example of this anywhere. This allows those who want to avoid re-minifying the bundle.js but still want it served via asset-pipeline to do so.