### PR TITLE
Fix enableES6 being ignored when keywords present

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/BabelJsProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/BabelJsProcessor.groovy
@@ -82,7 +82,7 @@ class BabelJsProcessor extends AbstractProcessor {
 		if(input.contains("export default")) {
 			newEcmascriptKeywordsFound = true;
 		}
-		if(!newEcmascriptKeywordsFound && assetFile instanceof JsAssetFile) {
+		if(assetFile instanceof JsAssetFile) {
 			if((!newEcmascriptKeywordsFound && !AssetPipelineConfigHolder.config?.enableES6 && !AssetPipelineConfigHolder.config?."enable-es6") || (newEcmascriptKeywordsFound && (AssetPipelineConfigHolder.config?.enableES6 == false || AssetPipelineConfigHolder.config?."enable-es6" == false))) {
 				return input
 			}


### PR DESCRIPTION
This tries to fix #260.

Getting this fix into a release after verification would be very much appreciated!