### PR TITLE
Upgrade Closure Compiler to v20210106

### DIFF
--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	doc         'org.codehaus.groovy:groovy-all:2.4.19'
 	doc         'org.fusesource.jansi:jansi:1.11'
 	api     'org.mozilla:rhino:1.7R4'
-	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20200614'
+	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20210106'
 	api 'org.slf4j:slf4j-api:1.7.28'
 	//api   'log4j:log4j:1.2.16'
 	testImplementation project(':asset-pipeline-classpath-test')

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 	api localGroovy()
 
 	api project(':asset-pipeline-core')
-	api 'com.google.javascript:closure-compiler-unshaded:v20200614'
+	api 'com.google.javascript:closure-compiler-unshaded:v20210106'
 	testImplementation('org.spockframework:spock-core:1.3-groovy-2.4')
 }
 


### PR DESCRIPTION
This version has some crucial bug fixes that allow certain libraries to minify (namely https://github.com/Countly/countly-sdk-web/blob/master/plugin/boomerang/countly_boomerang.js). Without it we get an error stating that the javascript is disallowed in strict mode.