### PR TITLE
Add node_modules resolution

### DIFF
--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -53,6 +53,7 @@ groovydoc {
 
 dependencies {
 	implementation    'org.codehaus.groovy:groovy:2.4.19'
+	implementation    'org.codehaus.groovy:groovy-json:2.4.19'
 	implementation    'org.codehaus.groovy:groovy-templates:2.4.19'
 	doc         'org.codehaus.groovy:groovy-all:2.4.19'
 	doc         'org.fusesource.jansi:jansi:1.11'


### PR DESCRIPTION
This makes it so applications using the pipeline can use a `node-modules` directory thereby enabling the usage of `npm` for package resolution.

With this approach, the package.json for your project needs to be at the asset root (`src/assets` or `grails-app/assets`) and you need to run npm from there. 

This means you can do this:
```
/path/to/project/grails-app/assets $  npm i react 
```
Then you can import the module as if it were an actual Node project.
```javascript
import React from 'react';
```

Using the modules in this way makes Intellij able to understand large libraries like React better as well.

This does _not_ use Node or NPM in _any way_ for the build process, only for package management, so things that require an actual Node environment will still need to be built outside of the project.

The `groovy-json` dependency was not added lightly, but if it needs removed I can try to work around it.

Please let me know if anything needs reworked or improved.