### PR TITLE
Added an option to flatten resolvers for the AssetCompile task

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompile.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompile.groovy
@@ -44,6 +44,9 @@ class AssetCompile extends DefaultTask {
     @Delegate AssetPipelineExtension pipelineExtension = new AssetPipelineExtension()
     //private FileCollection classpath;
 
+    @Input
+    boolean flattenResolvers = false
+
     @OutputDirectory
     File getDestinationDir() {
         pipelineExtension.compileDir ? new File(pipelineExtension.compileDir) : null
@@ -248,7 +251,7 @@ class AssetCompile extends DefaultTask {
                 registerJarResolvers(resolverFile)
             }
             else if (isAssetFolder) {
-                def fileResolver = new FileSystemAssetResolver(path, resolverFile.canonicalPath, false)
+                def fileResolver = new FileSystemAssetResolver(path, resolverFile.canonicalPath, flattenResolvers)
                 AssetPipelineConfigHolder.registerResolver(fileResolver)
             }
         }


### PR DESCRIPTION
This is required for making multi-module projects with Spring Boot