### PR TITLE
Allow configuring warningLevel 

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/ClosureCompilerProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/ClosureCompilerProcessor.groovy
@@ -19,6 +19,8 @@ package asset.pipeline.processors
 import asset.pipeline.AssetCompiler
 import com.google.javascript.jscomp.*
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode
+import com.sun.tools.javac.comp.Check
+
 import java.util.logging.Level
 import groovy.transform.CompileStatic
 
@@ -93,8 +95,6 @@ class ClosureCompilerProcessor {
 			optimizationLevel: 'SIMPLE' //WHITESPACE , ADVANCED
 		]
 
-		
-
 		minifyOptions = defaultOptions + minifyOptions
 		LanguageMode languageIn = evaluateLanguageMode(minifyOptions.get('languageMode') as String)
 		if(minifyOptions.targetLanguage) {
@@ -108,6 +108,18 @@ class ClosureCompilerProcessor {
 		setCompilationLevelOptions(compilerOptions, minifyOptions.get('optimizationLevel') as String)
 		if (minifyOptions.angularPass) {
 			compilerOptions.setAngularPass(true)
+		}
+		if (minifyOptions.containsKey('warningLevel')) {
+			final Map<String, String> warningLevel = minifyOptions.get('warningLevel') as Map<String, String>
+			if (warningLevel) {
+				for(Map.Entry<String, String> entry: warningLevel.entrySet()) {
+					final DiagnosticGroup diagnosticGroup = DiagnosticGroups.forName(entry.getKey())
+					final CheckLevel checkLevel = CheckLevel.valueOf(entry.getValue())
+					if (diagnosticGroup && checkLevel) {
+						compilerOptions.setWarningLevel(diagnosticGroup, checkLevel)
+					}
+				}
+			}
 		}
 	}
 

--- a/asset-pipeline-grails/src/docs/guide/configuration.gdoc
+++ b/asset-pipeline-grails/src/docs/guide/configuration.gdoc
@@ -37,10 +37,19 @@ grails.assets.minifyOptions = [
     languageMode: 'ES5',
     targetLanguage: 'ES5', //Can go from ES6 to ES5 for those bleeding edgers
     optimizationLevel: 'SIMPLE' //Or ADVANCED or WHITESPACE_ONLY
+    warningLevel: ['duplicate': 'OFF']
 ]
 {code}
 
 Above are the default values for the majority of Closure Compiler. For specifics on what these options do please refer to the documentation for Closure Compiler.
+
+Since 3.3.3, you could also configure the warningLevel for the Closure Compiler minifyOptions as:
+```
+grails.assets.minifyOptions = [
+    warningLevel: ['duplicate': 'OFF']
+]
+```
+The key in the `warningLevel` represents the registered name of @com.google.javascript.jscomp.DiagnosticGroup@ and the value must be supported @com.google.javascript.jscomp.CheckLevel@.
 
 h3. Mappings and Asset Taglib URLs
 


### PR DESCRIPTION
Add the ability to configure [warnings for Closure Compiler](https://github.com/google/closure-compiler/wiki/Warnings). For instance in order to disable duplicate variable checks, update  AssetPipelineExtension as following:

```
assets {
    minifyJs = true
    minifyCss = true
    minifyOptions = [
        warningLevel: [
            duplicate: "WARNING",
            checkVars: "WARNING"
        ]
    ]
}
```