### PR TITLE
Update AssetCompile task classpath

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompile.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompile.groovy
@@ -173,7 +173,7 @@ class AssetCompile extends DefaultTask {
     @Optional
     public FileCollection getClasspath() {
         try {
-            FileCollection runtimeFiles = getProject().configurations.getByName('runtime') as FileCollection
+            FileCollection runtimeFiles = getProject().configurations.getByName('runtimeClasspath') as FileCollection
             
             
             FileCollection totalFiles = runtimeFiles


### PR DESCRIPTION
Replace runtime with runtimeClasspath. This fixes grails/grails-core#11999 and #279