### PR TITLE
Gradle 7 Compatibility: Issue #283 Updated Deprecated RunTime Configuration. This would be a backwards i…

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -193,7 +193,7 @@ class AssetPipelinePlugin implements Plugin<Project> {
                 Configuration runtimeConfiguration = project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
                 runtimeConfiguration.extendsFrom configuration        
             } else {
-                Configuration runtimeConfiguration = project.configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME)
+                Configuration runtimeConfiguration = project.configurations.getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
                 runtimeConfiguration.extendsFrom configuration        
             }
             


### PR DESCRIPTION
Issue #283 

Updated Deprecated RunTime Configuration. This would be a backwards incompatible change with Gradle < 3.4. But would allow compatibility with Gradle 7.x.

RUNTIME_CONFIGURATION_NAME
Consumers should use RUNTIME_ELEMENTS_CONFIGURATION_NAME instead.
The name of the "runtime" configuration. This configuration is deprecated and doesn't represent a correct view of the runtime dependencies of a component.