### PR TITLE
Avoid dot-notation warnings using Grails 5

### DIFF
--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -103,7 +103,7 @@ class AssetPipelineGrailsPlugin extends grails.plugins.Plugin {
         }
 
 
-        AssetPipelineConfigHolder.config = assetsConfig
+        AssetPipelineConfigHolder.config = assetsConfig.toFlatConfig()
         if (BuildSettings.TARGET_DIR) {
             AssetPipelineConfigHolder.config.cacheLocation = new File((File) BuildSettings.TARGET_DIR, ".assetcache").canonicalPath
         }

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetProcessorService.groovy
@@ -4,6 +4,7 @@ package asset.pipeline.grails
 import asset.pipeline.AssetHelper
 import grails.core.GrailsApplication
 import grails.util.Environment
+import org.grails.config.NavigableMap
 
 import javax.annotation.Resource
 import javax.servlet.http.HttpServletRequest
@@ -109,8 +110,9 @@ class AssetProcessorService {
 	}
 
 
-	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase, final Map conf = grailsApplication.config.getProperty('grails.assets',Map,[:])) {
-		final String url = getConfigBaseUrl(req, conf)
+	String assetBaseUrl(final HttpServletRequest req, final UrlBase urlBase, final NavigableMap conf = grailsApplication.config.getProperty('grails.assets',Map,[:])) {
+		Map map = conf.toFlatConfig()
+		final String url = getConfigBaseUrl(req, map)
 		if (url) {
 			return url
 		}


### PR DESCRIPTION
For issue https://github.com/bertramdev/asset-pipeline/issues/285

Avoid dot-notation warnings using Grails 5
The main issue is `config.getProperty('grails.assets', Map, [:])` returns a NavigableMap object, so to avoid the warning I translated that to a Map using `toFlatConfig()` method
