### PR TITLE
Allow to resolve absolute paths in sass-dart-asset-pipeline

### DIFF
--- a/sass-asset-pipeline/assets/stylesheets/webjar-import/main.scss
+++ b/sass-asset-pipeline/assets/stylesheets/webjar-import/main.scss
@@ -1,0 +1,1 @@
+@import "/webjars/bootstrap/5.1.3/scss/bootstrap";

--- a/sass-asset-pipeline/build.gradle
+++ b/sass-asset-pipeline/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.4'
 
     testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.21'
+
+    compile 'org.webjars:bootstrap:5.1.3'
 }
 
 publishing {

--- a/sass-asset-pipeline/src/test/groovy/asset/pipeline/jsass/SassProcessorSpec.groovy
+++ b/sass-asset-pipeline/src/test/groovy/asset/pipeline/jsass/SassProcessorSpec.groovy
@@ -94,4 +94,17 @@ class SassProcessorSpec extends Specification {
 		then:
 		output.contains('Twitter')
 	}
+
+	void "should compile webjar imports"() {
+		given:
+		AssetPipelineConfigHolder.resolvers = []
+		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('test','assets'))
+		AssetPipelineConfigHolder.registerResolver(new ClasspathAssetResolver('classpath','META-INF/resources'))
+		def assetFile = AssetHelper.fileForFullName('webjar-import/main.scss')
+		def processor = new SassProcessor()
+		when:
+		def output = processor.process(assetFile.inputStream.text,assetFile)
+		then:
+		output.contains('Twitter')
+	}
 }

--- a/sass-dart-asset-pipeline/assets/stylesheets/absolute-import/main.scss
+++ b/sass-dart-asset-pipeline/assets/stylesheets/absolute-import/main.scss
@@ -1,0 +1,1 @@
+@import "/bootstrap/bootstrap";

--- a/sass-dart-asset-pipeline/assets/stylesheets/webjar-import/main.scss
+++ b/sass-dart-asset-pipeline/assets/stylesheets/webjar-import/main.scss
@@ -1,0 +1,1 @@
+@import "/webjars/bootstrap/5.1.3/scss/bootstrap";

--- a/sass-dart-asset-pipeline/build.gradle
+++ b/sass-dart-asset-pipeline/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.4'
 
     testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.21'
+
+    compile 'org.webjars:bootstrap:5.1.3'
+
 }
 
 publishing {

--- a/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
+++ b/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
@@ -44,9 +44,9 @@ class SassAssetFileLoader {
             prev = baseFile.path
         }
         else {
-            // Resolve the real base path for this import
+            // Resolve the real base path for this import if it's not an absolute path
             String priorParent = importMap[prev]
-            if (priorParent) {
+            if (priorParent && !prev.startsWith('/')) {
                 Path priorParentPath = Paths.get(priorParent)
                 if (priorParentPath.parent) {
                     prev = "${priorParentPath.parent.toString()}/${prev}"

--- a/sass-dart-asset-pipeline/src/test/groovy/asset/pipeline/dart/SassProcessorSpec.groovy
+++ b/sass-dart-asset-pipeline/src/test/groovy/asset/pipeline/dart/SassProcessorSpec.groovy
@@ -18,6 +18,7 @@ package asset.pipeline.dart
 
 import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
+import asset.pipeline.fs.ClasspathAssetResolver
 import asset.pipeline.fs.FileSystemAssetResolver
 import spock.lang.Specification
 
@@ -101,6 +102,31 @@ class SassProcessorSpec extends Specification {
 		def processor = new SassProcessor()
 		when:
 		def output = processor.process(assetFile.inputStream.text, assetFile)
+		then:
+		output.contains('Twitter')
+	}
+
+	void "should compile absolute imports"() {
+		given:
+		AssetPipelineConfigHolder.resolvers = []
+		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('test','assets'))
+		def assetFile = AssetHelper.fileForFullName('absolute-import/main.scss')
+		def processor = new SassProcessor()
+		when:
+		def output = processor.process(assetFile.inputStream.text,assetFile)
+		then:
+		output.contains('Twitter')
+    }
+
+	void "should compile webjar imports"() {
+		given:
+		AssetPipelineConfigHolder.resolvers = []
+		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('test','assets'))
+		AssetPipelineConfigHolder.registerResolver(new ClasspathAssetResolver('classpath','META-INF/resources'))
+		def assetFile = AssetHelper.fileForFullName('webjar-import/main.scss')
+		def processor = new SassProcessor()
+		when:
+		def output = processor.process(assetFile.inputStream.text,assetFile)
 		then:
 		output.contains('Twitter')
 	}


### PR DESCRIPTION
This enables the same behaviour as in sass-asset-pipeline.
Added webjar test cases in bot sass asset-pipelines.

fixes #297