### PR TITLE
Reduce exported transient depencencies

### DIFF
--- a/asset-pipeline-classpath-test/build.gradle
+++ b/asset-pipeline-classpath-test/build.gradle
@@ -36,5 +36,5 @@ repositories {
 
 
 dependencies {
-	implementation localGroovy()
+	compileOnly localGroovy()
 }

--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -55,9 +55,9 @@ groovydoc {
 }
 
 dependencies {
-	implementation    'org.codehaus.groovy:groovy:2.4.19'
-	implementation    'org.codehaus.groovy:groovy-json:2.4.19'
-	implementation    'org.codehaus.groovy:groovy-templates:2.4.19'
+	compileOnly    'org.codehaus.groovy:groovy:2.4.19'
+	compileOnly    'org.codehaus.groovy:groovy-json:2.4.19'
+	compileOnly    'org.codehaus.groovy:groovy-templates:2.4.19'
 	doc         'org.codehaus.groovy:groovy-all:2.4.19'
 	doc         'org.fusesource.jansi:jansi:1.11'
 	api     'org.mozilla:rhino:1.7R4'

--- a/asset-pipeline-grails/build.gradle
+++ b/asset-pipeline-grails/build.gradle
@@ -111,15 +111,14 @@ publishing {
 
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-logging'
-    implementation "org.springframework.boot:spring-boot-starter-actuator"
-    implementation "org.springframework.boot:spring-boot-autoconfigure"
-    implementation "org.springframework.boot:spring-boot-starter-tomcat"
+    compileOnly 'org.springframework.boot:spring-boot-starter-logging'
+    compileOnly "org.springframework.boot:spring-boot-starter-actuator"
+    compileOnly "org.springframework.boot:spring-boot-autoconfigure"
+    compileOnly "org.springframework.boot:spring-boot-starter-tomcat"
 
-    implementation "org.grails:grails-web-boot"
-    implementation "org.grails:grails-dependencies"
-    implementation 'javax.servlet:javax.servlet-api:3.1.0'
-    implementation "org.grails:grails-dependencies"
+    compileOnly "org.grails:grails-web-boot"
+    compileOnly "org.grails:grails-dependencies"
+    compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
     implementation project(':asset-pipeline-core'), {
         exclude group:'org.mozilla', module:'rhino'
         exclude group:'com.google.javascript', module:'closure-compiler-unshaded'

--- a/asset-pipeline-spring-boot/build.gradle
+++ b/asset-pipeline-spring-boot/build.gradle
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-	implementation    'org.codehaus.groovy:groovy:2.4.19'
+	compileOnly    'org.codehaus.groovy:groovy:2.4.19'
 	api     project(':asset-pipeline-core')
 	api     project(':asset-pipeline-servlet')
 	api     'org.springframework.boot:spring-boot-starter-web:1.5.1.RELEASE'

--- a/coffee-asset-pipeline/build.gradle
+++ b/coffee-asset-pipeline/build.gradle
@@ -40,7 +40,7 @@ sourceSets {
 
 dependencies {
 	api project(':asset-pipeline-core')
-	implementation 'org.codehaus.groovy:groovy:2.4.19'
+	compileOnly 'org.codehaus.groovy:groovy:2.4.19'
     api 'org.mozilla:rhino:1.7R4'
 
     testImplementation "org.spockframework:spock-core:1.3-groovy-2.4"

--- a/compass-asset-pipeline/build.gradle
+++ b/compass-asset-pipeline/build.gradle
@@ -43,7 +43,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:2.4.19'
+    compileOnly 'org.codehaus.groovy:groovy-all:2.4.19'
 	api project(':asset-pipeline-core')
     // api 'log4j:log4j:1.2.17'
     // api 'org.yaml:snakeyaml:1.26'

--- a/groocss-asset-pipeline/build.gradle
+++ b/groocss-asset-pipeline/build.gradle
@@ -40,7 +40,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:2.4.19'
+    compileOnly 'org.codehaus.groovy:groovy-all:2.4.19'
     api project(':asset-pipeline-core')
 	api "org.groocss:groocss:1.0-M1"
 

--- a/handlebars-asset-pipeline/build.gradle
+++ b/handlebars-asset-pipeline/build.gradle
@@ -41,7 +41,7 @@ sourceSets {
 
 dependencies {
 	api project(':asset-pipeline-core')
-	implementation 'org.codehaus.groovy:groovy-all:2.4.19'
+	compileOnly 'org.codehaus.groovy:groovy-all:2.4.19'
     api 'org.mozilla:rhino:1.7R4'
     // api 'log4j:log4j:1.2.17'
 

--- a/jsx-asset-pipeline/build.gradle
+++ b/jsx-asset-pipeline/build.gradle
@@ -45,7 +45,7 @@ java {
 
 dependencies {
     api project(':asset-pipeline-core')
-    implementation 'org.codehaus.groovy:groovy:2.4.19'
+    compileOnly 'org.codehaus.groovy:groovy:2.4.19'
     api 'org.mozilla:rhino:1.7R4'
 
     testImplementation "org.spockframework:spock-core:1.3-groovy-2.4"

--- a/less-asset-pipeline/build.gradle
+++ b/less-asset-pipeline/build.gradle
@@ -43,7 +43,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:2.4.19'
+    compileOnly 'org.codehaus.groovy:groovy-all:2.4.19'
     api project(':asset-pipeline-core')
     api 'org.mozilla:rhino:1.7R4'
     api 'org.slf4j:slf4j-api:1.7.28'

--- a/sass-asset-pipeline/build.gradle
+++ b/sass-asset-pipeline/build.gradle
@@ -42,7 +42,7 @@ java {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:2.4.19'
+    compileOnly 'org.codehaus.groovy:groovy-all:2.4.19'
 	api project(':asset-pipeline-core')
     api 'org.slf4j:slf4j-api:1.7.28'
     api 'io.bit3:jsass:5.10.4'

--- a/typescript-asset-pipeline/build.gradle
+++ b/typescript-asset-pipeline/build.gradle
@@ -41,7 +41,7 @@ java {
 dependencies {
 	api project(':asset-pipeline-core')
     api project(':jsx-asset-pipeline')
-	implementation 'org.codehaus.groovy:groovy:2.4.19'
+	compileOnly 'org.codehaus.groovy:groovy:2.4.19'
     api 'org.mozilla:rhino:1.7R4'
     // api 'log4j:log4j:1.2.17'
 


### PR DESCRIPTION
Commit 1192aa1 migrated Gradle dependency configurations from
`provided` to `implementation`. This altered the build output.

Particularly, the Grails pipeline exports many unnecessary
depencencies.

AFAIK Gradle's `compileOnly` is the replacement for the deprecated
`provided` configuration, is it not?