### PR TITLE
fixes #320 groocss-asset-pipeline extension module methods not working

### DIFF
--- a/groocss-asset-pipeline/build.gradle
+++ b/groocss-asset-pipeline/build.gradle
@@ -42,7 +42,7 @@ sourceSets {
 dependencies {
     compileOnly 'org.codehaus.groovy:groovy-all:2.4.19'
     api project(':asset-pipeline-core')
-	api "org.groocss:groocss:1.0-M1"
+	api "org.groocss:groocss:1.0-M2"
 
     testImplementation "org.spockframework:spock-core:1.1-groovy-2.4"
 }

--- a/groocss-asset-pipeline/src/test/groovy/asset/pipeline/groocss/GroocssAssetFileSpec.groovy
+++ b/groocss-asset-pipeline/src/test/groovy/asset/pipeline/groocss/GroocssAssetFileSpec.groovy
@@ -1,0 +1,52 @@
+package asset.pipeline.groocss
+
+import asset.pipeline.AssetCompiler
+import asset.pipeline.AssetFile
+import asset.pipeline.AssetHelper
+import asset.pipeline.AssetPipelineConfigHolder
+import asset.pipeline.fs.FileSystemAssetResolver
+import spock.lang.Specification
+
+class GroocssAssetFileSpec extends Specification {
+    void setup() {
+        AssetPipelineConfigHolder.resolvers = []
+        AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('simple','src/test/resources', false))
+    }
+
+    void cleanup() {
+        AssetPipelineConfigHolder.resolvers = []
+    }
+
+    void 'applying compiler to simple groocss asset file succeeds'() {
+        given:
+        AssetFile assetFile = AssetHelper.fileForFullName('simple.css.groovy')
+
+        when:
+        String css = assetFile.processedStream(new AssetCompiler())
+
+        then:
+        css == ".border-1{border: 1px;}"
+    }
+
+    void 'applying compiler to nested type groocss asset file succeeds'() {
+        given:
+        AssetFile assetFile = AssetHelper.fileForFullName('nested.css.groovy')
+
+        when:
+        String css = assetFile.processedStream(new AssetCompiler())
+
+        then:
+        css == '.logo-wrapper > img{width: 15em;}\n.logo-wrapper{width: 50%;\n\tdisplay: flex;\n\tjustify-content: center;\n\talign-items: center;\n\topacity: 60%;}'
+    }
+
+    void 'applying compiler to asset file with measures succeeds'() {
+        given:
+        AssetFile assetFile = AssetHelper.fileForFullName('measures.css.groovy')
+
+        when:
+        String css = assetFile.processedStream(new AssetCompiler())
+
+        then:
+        css == '.border-1{border: 1px;}\n.border-2{border: 2em;}'
+    }
+}

--- a/groocss-asset-pipeline/src/test/resources/measures.css.groovy
+++ b/groocss-asset-pipeline/src/test/resources/measures.css.groovy
@@ -1,0 +1,2 @@
+_.'border-1' { border 1.px }
+_.'border-2' { border 2.em }

--- a/groocss-asset-pipeline/src/test/resources/nested.css.groovy
+++ b/groocss-asset-pipeline/src/test/resources/nested.css.groovy
@@ -1,0 +1,8 @@
+_.'logo-wrapper' {
+    width '50%'
+    display 'flex'
+    justifyContent 'center'
+    alignItems 'center'
+    opacity '60%'
+    add '> img', { width '15em' }
+}

--- a/groocss-asset-pipeline/src/test/resources/simple.css.groovy
+++ b/groocss-asset-pipeline/src/test/resources/simple.css.groovy
@@ -1,0 +1,1 @@
+_.'border-1' { border '1px' }


### PR DESCRIPTION
It seems that version 1.0-M1 doesn't provide support for extension module for measurement methods