### PR TITLE
Fix AssetConnection#connect for Java 17

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/AssetConnection.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/AssetConnection.groovy
@@ -11,6 +11,8 @@ import asset.pipeline.AssetHelper;
 @CompileStatic
 public class AssetConnection extends URLConnection
 {
+	private boolean connected = false;
+
 	public AssetConnection(URL u) {
 		super(u);
 	}

--- a/compass-asset-pipeline/src/main/groovy/sun/net/www/protocol/asset/AssetConnection.groovy
+++ b/compass-asset-pipeline/src/main/groovy/sun/net/www/protocol/asset/AssetConnection.groovy
@@ -11,6 +11,8 @@ import asset.pipeline.AssetHelper;
 @CompileStatic
 public class AssetConnection extends URLConnection
 {
+	private boolean connected = false;
+
 	public AssetConnection(URL u) {
 		super(u);
 	}


### PR DESCRIPTION
Using the following versions we run into an error with the less compiler:
* Grails: 6.2.0
* Groovy: 3.0.21
* Gradle: 7.6.4
* Java: 17

When running the application locally the asset compilation using the standard less compiler failed with the following exception for each less asset:
```
Failed to open file JavaException: groovy.lang.MissingPropertyException: No such property: connected for class: asset.pipeline.utils.AssetConnection
failed to open file  asset:/path/to/asset.less   JavaException: groovy.lang.MissingPropertyException: No such property: connected for class: asset.pipeline.utils.AssetConnection
```

The reason is the call of `AssetConnection#connect` which sets the `connected` property of its parent class `java.net.URLConnection`. As this property is `protected` and the classes are not in the same namespace, this modification is not allowed.

I got the idea for the fix from [Creating a Custom URL Connection](https://www.baeldung.com/java-custom-url-connection)

**buildSrc/build.gradle**
```
dependencies {
    implementation("org.grails:grails-gradle-plugin:6.2.0")
    implementation("com.bertramlabs.plugins:asset-pipeline-gradle:4.4.0")
    implementation("com.bertramlabs.plugins:less-asset-pipeline:4.4.0")
}
```

**build.gradle**
```
plugins {
    id "com.bertramlabs.asset-pipeline"
}
dependencies {
	assets "com.bertramlabs.plugins:less-asset-pipeline:4.4.0"
	runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:4.3.0"
    runtimeOnly "com.bertramlabs.plugins:less-asset-pipeline:4.4.0"
}
assets {
    developmentRuntime = true
    configOptions = [
            less: [
                    compiler: "standard"
            ]
    ]
}
```

**buildSrc/build.gradle**
```
grails {
    assets {
        less{
            compiler = '"tandard"
        }
    }
}
```