### PR TITLE
update closure-compiler-unshaded to v20240317

### DIFF
--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     api("org.graalvm.js:js:22.0.0.2")
     api("org.graalvm.js:js-scriptengine:22.0.0.2")
 
-	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20230802'
+	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20240317'
 	api 'org.slf4j:slf4j-api:1.7.28'
 	//api   'log4j:log4j:1.2.16'
 	testImplementation project(':asset-pipeline-classpath-test')

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 	api localGroovy()
 
 	api project(':asset-pipeline-core')
-	api 'com.google.javascript:closure-compiler-unshaded:v20230802'
+	api 'com.google.javascript:closure-compiler-unshaded:v20240317'
 	testImplementation('org.spockframework:spock-core:1.3-groovy-2.4')
 }
 


### PR DESCRIPTION
Update to the current version of the closure-compiler-unshaded #326

( https://github.com/bertramdev/asset-pipeline/pull/329#issuecomment-2097652579 )