### PR TITLE
Don't cache grails assets, re-fetch the manifest and asset each time

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetPipelineClassLoaderEntry.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetPipelineClassLoaderEntry.groovy
@@ -16,17 +16,6 @@ class AssetPipelineClassLoaderEntry {
 		URL res = classLoader.getResource(MANIFEST_LOCATION)
 		if(res) {
 			def manifestProps = new Properties()
-			def propertiesStream = res.openStream()
-			manifestProps.load(propertiesStream)
-			manifest = manifestProps
-		}
-	}
-
-	public Properties getFreshManifest() {
-		this.classLoader = classLoader
-		URL res = classLoader.getResource(MANIFEST_LOCATION)
-		if(res) {
-			def manifestProps = new Properties()
 			URLConnection resConnection = res.openConnection()
 			resConnection.setUseCaches(false)
 			def propertiesStream = resConnection.getInputStream()
@@ -34,4 +23,5 @@ class AssetPipelineClassLoaderEntry {
 			manifest = manifestProps
 		}
 	}
+
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetPipelineClassLoaderEntry.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetPipelineClassLoaderEntry.groovy
@@ -21,4 +21,17 @@ class AssetPipelineClassLoaderEntry {
 			manifest = manifestProps
 		}
 	}
+
+	public Properties getFreshManifest() {
+		this.classLoader = classLoader
+		URL res = classLoader.getResource(MANIFEST_LOCATION)
+		if(res) {
+			def manifestProps = new Properties()
+			URLConnection resConnection = res.openConnection()
+			resConnection.setUseCaches(false)
+			def propertiesStream = resConnection.getInputStream()
+			manifestProps.load(propertiesStream)
+			manifest = manifestProps
+		}
+	}
 }

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -61,7 +61,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 		if(classRegistryKey) {
 			AssetPipelineClassLoaderEntry classLoaderEntry = AssetPipelineConfigHolder.classLoaderRegistry[classRegistryKey]
 			fileUri = fileUri.substring(classRegistryKey.length())
-			final Properties manifest = classLoaderEntry.getFreshManifest()
+			final Properties manifest = classLoaderEntry.manifest
 			String manifestPath = fileUri
 			if(fileUri == '' || fileUri.endsWith('/')) {
 				fileUri += indexFile

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -61,7 +61,7 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 		if(classRegistryKey) {
 			AssetPipelineClassLoaderEntry classLoaderEntry = AssetPipelineConfigHolder.classLoaderRegistry[classRegistryKey]
 			fileUri = fileUri.substring(classRegistryKey.length())
-			final Properties manifest = classLoaderEntry.manifest
+			final Properties manifest = classLoaderEntry.getFreshManifest()
 			String manifestPath = fileUri
 			if(fileUri == '' || fileUri.endsWith('/')) {
 				fileUri += indexFile
@@ -104,7 +104,9 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 					try {
 						final byte[] buffer = new byte[102400]
 						int len
-						inputStream = file.openStream()
+						URLConnection fileConnection = file.openConnection()
+						fileConnection.setUseCaches(false)
+						inputStream = fileConnection.getInputStream()
 						final ServletOutputStream out = response.outputStream
 						while((len = inputStream.read(buffer)) != -1) {
 							out.write(buffer, 0, len)


### PR DESCRIPTION
This solves an issue with assets not being correctly reloaded if the jar file they are pulled from changes without restarting the grails process