### PR TITLE
Default skipNonDigests = true for Grails apps. Fixes #341

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -50,8 +50,8 @@ class AssetPipelinePlugin implements Plugin<Project> {
         def config = AssetPipelineConfigHolder.config != null ? AssetPipelineConfigHolder.config : [:]
         config.cacheLocation = "${project.buildDir}/.assetcache"
         if (project.extensions.findByName('grails')) {
-            
             defaultConfiguration.assetsPath = 'grails-app/assets'
+            defaultConfiguration.skipNonDigests = true
         } else {
             defaultConfiguration.assetsPath = "${project.projectDir}/src/assets"
         }


### PR DESCRIPTION
> By default both digested named versions of assets as well as non digested named versions are generated as well as the gzip equivalents. Some frameworks dont actually need the non digested named versions ( ratpack, grails, spring-boot, and servlets). These frameworks take advantage of the manifest.properties file discussed earlier in the documentation to properly map requests for non digested file names to the digested equivalent and preserve compatibility with libraries that may not work well with digested file names.

### "Some frameworks don't actually need the non digested named versions (grails)"

The default behavior currently works in contrary of what the [ducumentation](https://github.com/bertramdev/asset-pipeline/blob/f84c4dcaee82e9d1932db1f301ad1e63561f1b52/asset-pipeline-docs/src/asciidoc/gradle/configuration.adoc) suggests 

Sets the following default behavior for Grails Apps

```gradle
assets {
    skipNonDigests = true
}
```