### PR TITLE
Default skipNonDigests = true for Gradle and Grails Fixes #341

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelineExtensionImpl.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelineExtensionImpl.groovy
@@ -14,7 +14,7 @@ class AssetPipelineExtensionImpl implements AssetPipelineExtension {
     boolean enableSourceMaps = true
     boolean minifyCss = true
     boolean enableDigests = true
-    boolean skipNonDigests = false
+    boolean skipNonDigests = true
     boolean enableGzip = true
     boolean packagePlugin=false
     boolean developmentRuntime=true


### PR DESCRIPTION
Alternative to #343 making skipNonDigests the default behavior for Grails *and* Gradle apps.