### PR TITLE
Compile asset-pipeline-core with Groovy 3

### DIFF
--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -54,9 +54,9 @@ groovydoc {
 }
 
 dependencies {
-	compileOnly    'org.apache.groovy:groovy:4.0.22'
-	compileOnly    'org.apache.groovy:groovy-json:4.0.22'
-	compileOnly    'org.apache.groovy:groovy-templates:4.0.22'
+	compileOnly    'org.codehaus.groovy:groovy:3.0.20'
+	compileOnly    'org.codehaus.groovy:groovy-json:3.0.20'
+	compileOnly    'org.codehaus.groovy:groovy-templates:3.0.20'
 	doc         'org.apache.groovy:groovy-all:4.0.22'
 	doc         'org.fusesource.jansi:jansi:1.11'
 	compileOnly     'org.mozilla:rhino:1.7R4'


### PR DESCRIPTION
Compile asset-pipeline-core with Groovy 3 to avoid Groovy 4 incompatibility when Gradle runs it in asset-pipeline-gradle with Groovy 3

When compiled with Groovy 4, the compiler uses groovy.lang.IntRange(boolean, boolean, int, int), which does not exist in Groovy 3 and causes the NoSuchMethodError when Gradle runs the class with Groovy 3.0.22.

The specific line that gets transformed to use groovy.lang.IntRange(boolean, boolean, int, int) when compiled with Groovy 4, which does not exist in Groovy 3.  https://docs.groovy-lang.org/3.0.22/html/api/groovy/lang/IntRange.html

https://github.com/bertramdev/asset-pipeline/blob/186b7bee2ae092aad88ecd6f19b45a0109e179cc/asset-pipeline-core/src/main/groovy/asset/pipeline/GenericAssetFile.groovy#L57

**Compiled with Groovy 3:**

return pathArgs.size() == 1 ? (String)ShortTypeHandling.castToString((Object)null) : DefaultGroovyMethods.join(DefaultGroovyMethods.getAt(pathArgs, new IntRange(true, 0, pathArgs.size() - 2)), "/");

**Compiled with Groovy 4:**

return pathArgs.size() == 1 ? null.cast<invokedynamic>((Object)null) : DefaultGroovyMethods.join(DefaultGroovyMethods.getAt(pathArgs, new IntRange(true, **true,** 0, pathArgs.size() - 2)), "/");
