### PR TITLE
Expose org.graalvm.sdk:graal-sdk dependency

### DIFF
--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 	doc         'org.apache.groovy:groovy-all:4.0.22'
 	doc         'org.fusesource.jansi:jansi:1.11'
 	compileOnly     'org.mozilla:rhino:1.7R4'
-	compileOnly("org.graalvm.sdk:graal-sdk:22.0.0.2")
+	api("org.graalvm.sdk:graal-sdk:22.0.0.2")
     compileOnly("org.graalvm.js:js:22.0.0.2")
     compileOnly("org.graalvm.js:js-scriptengine:22.0.0.2")
 	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20240317'


### PR DESCRIPTION
This saves having to add it to every Grails 7 application