### PR TITLE
GrailsFilters moved to grails-web-common module

### DIFF
--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -25,7 +25,7 @@ import asset.pipeline.fs.*
 import asset.pipeline.*
 import grails.util.BuildSettings
 import org.grails.plugins.BinaryGrailsPlugin
-import org.grails.spring.config.http.GrailsFilters
+import org.grails.web.config.http.GrailsFilters
 import groovy.util.logging.Commons
 import org.springframework.util.ClassUtils
 

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -25,7 +25,7 @@ import asset.pipeline.fs.*
 import asset.pipeline.*
 import grails.util.BuildSettings
 import org.grails.plugins.BinaryGrailsPlugin
-import org.grails.config.http.GrailsFilters
+import org.grails.spring.config.http.GrailsFilters
 import groovy.util.logging.Commons
 import org.springframework.util.ClassUtils
 


### PR DESCRIPTION
GrailsFilters has been moved as it is strictly a configuration class and dependent on Spring. 
It seems like `grails-spring` is already resolved by all the potential locations that need this class and there could be cases where you might not want the controller plugin.  e.g. [grails-boot](https://github.com/grails/grails-boot)