### PR TITLE
Remove unneeded grailsLinkGenerator already created by grails-plugin-url-mappings

### DIFF
--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -15,10 +15,7 @@
  */
 package asset.pipeline
 
-import asset.pipeline.AssetPipelineFilter
 import asset.pipeline.grails.AssetProcessorService
-import asset.pipeline.grails.LinkGenerator
-import asset.pipeline.grails.CachingLinkGenerator
 import asset.pipeline.grails.AssetResourceLocator
 import asset.pipeline.grails.fs.*
 import asset.pipeline.fs.*
@@ -111,14 +108,7 @@ class AssetPipelineGrailsPlugin extends grails.plugins.Plugin {
         if (BuildSettings.TARGET_DIR) {
             AssetPipelineConfigHolder.config.cacheLocation = new File((File) BuildSettings.TARGET_DIR, ".assetcache").canonicalPath
         }
-        // Register Link Generator
-        String serverURL = config?.getProperty('grails.serverURL', String, null)
-        boolean cacheUrls = config?.getProperty('grails.web.linkGenerator.useCache', Boolean, true)
-
         assetProcessorService(AssetProcessorService)
-        grailsLinkGenerator(cacheUrls ? CachingLinkGenerator : LinkGenerator, serverURL) { bean ->
-            bean.autowire = true
-        }
 
         assetResourceLocator(AssetResourceLocator) { bean ->
             bean.parent = "abstractGrailsResourceLocator"


### PR DESCRIPTION
I am not sure why it is there in the first place?

```
Overriding bean definition for bean 'grailsLinkGenerator' with a different definition: replacing [Root bean: class=null; scope=; abstract=false; lazyInit=null; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; fallback=false; factoryBeanName=org.grails.plugins.web.mapping.UrlMappingsAutoConfiguration; factoryMethodName=grailsLinkGenerator; initMethodNames=null; destroyMethodNames=[(inferred)]; defined in class path resource [org/grails/plugins/web/mapping/UrlMappingsAutoConfiguration.class]] with [Generic bean: class=asset.pipeline.grails.CachingLinkGenerator; scope=singleton; abstract=false; lazyInit=false; autowireMode=1; dependencyCheck=0; autowireCandidate=true; primary=false; fallback=false; factoryBeanName=null; factoryMethodName=null; initMethodNames=null; destroyMethodNames=null]
```