### PR TITLE
Revert "Remove unneeded grailsLinkGenerator already created by grails-plugin-url-mappings"

### DIFF
--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -15,7 +15,10 @@
  */
 package asset.pipeline
 
+import asset.pipeline.AssetPipelineFilter
 import asset.pipeline.grails.AssetProcessorService
+import asset.pipeline.grails.LinkGenerator
+import asset.pipeline.grails.CachingLinkGenerator
 import asset.pipeline.grails.AssetResourceLocator
 import asset.pipeline.grails.fs.*
 import asset.pipeline.fs.*
@@ -108,7 +111,14 @@ class AssetPipelineGrailsPlugin extends grails.plugins.Plugin {
         if (BuildSettings.TARGET_DIR) {
             AssetPipelineConfigHolder.config.cacheLocation = new File((File) BuildSettings.TARGET_DIR, ".assetcache").canonicalPath
         }
+        // Register Link Generator
+        String serverURL = config?.getProperty('grails.serverURL', String, null)
+        boolean cacheUrls = config?.getProperty('grails.web.linkGenerator.useCache', Boolean, true)
+
         assetProcessorService(AssetProcessorService)
+        grailsLinkGenerator(cacheUrls ? CachingLinkGenerator : LinkGenerator, serverURL) { bean ->
+            bean.autowire = true
+        }
 
         assetResourceLocator(AssetResourceLocator) { bean ->
             bean.parent = "abstractGrailsResourceLocator"


### PR DESCRIPTION
Reverts bertramdev/asset-pipeline#362

This needs to go back into master because it will break 4.x

would have been nice if you didn't use the same class names 

😭 