### PR TITLE
5.0.x fix graalvm resolution

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,2 +1,3 @@
-gradle=7.4
-java=17.0.5-tem
+java=17.0.13-librca
+gradle=8.12.1
+

--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -60,9 +60,9 @@ dependencies {
 	doc         'org.apache.groovy:groovy-all:4.0.22'
 	doc         'org.fusesource.jansi:jansi:1.11'
 	compileOnly     'org.mozilla:rhino:1.7R4'
-	api("org.graalvm.sdk:graal-sdk:22.0.0.2")
-    api("org.graalvm.js:js:22.0.0.2")
-    api("org.graalvm.js:js-scriptengine:22.0.0.2")
+	compileOnly 	"org.graalvm.sdk:graal-sdk:22.0.0.2"
+	compileOnly 	"org.graalvm.js:js:22.0.0.2"
+	compileOnly 	"org.graalvm.js:js-scriptengine:22.0.0.2"
 	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20240317'
 	api 'org.slf4j:slf4j-api:1.7.28'
 	//api   'log4j:log4j:1.2.16'

--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -54,23 +54,27 @@ groovydoc {
 }
 
 dependencies {
-	compileOnly    'org.codehaus.groovy:groovy:3.0.20'
-	compileOnly    'org.codehaus.groovy:groovy-json:3.0.20'
-	compileOnly    'org.codehaus.groovy:groovy-templates:3.0.20'
-	doc         'org.apache.groovy:groovy-all:4.0.22'
-	doc         'org.fusesource.jansi:jansi:1.11'
-	compileOnly     'org.mozilla:rhino:1.7R4'
-	compileOnly 	"org.graalvm.sdk:graal-sdk:$graalvmVersion"
-	compileOnly 	"org.graalvm.js:js-community:$graalvmVersion"
-	compileOnly 	"org.graalvm.js:js-scriptengine:$graalvmVersion"
-	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20240317'
-	api 'org.slf4j:slf4j-api:1.7.28'
-	//api   'log4j:log4j:1.2.16'
+
+	doc "org.apache.groovy:groovy:$groovy4Version"
+	doc "org.apache.groovy:groovy-ant:$groovy4Version"
+	doc "org.apache.groovy:groovy-templates:$groovy4Version"
+    doc "com.github.javaparser:javaparser-core:$javaparserVersion"
+
+	// Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
+	compileOnly "com.google.javascript:closure-compiler-unshaded:$closureCompilerVersion"
+	compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+	compileOnly "org.codehaus.groovy:groovy-json:$groovy3Version"
+	compileOnly "org.codehaus.groovy:groovy-templates:$groovy3Version"
+	compileOnly "org.graalvm.polyglot:polyglot:$graalvmVersion"
+	compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
+
 	testImplementation project(':asset-pipeline-classpath-test')
-	testImplementation 'org.apache.groovy:groovy-all:4.0.22'
-	testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
-	testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.28'
-	compileOnly 'org.slf4j:slf4j-simple:1.7.28'
+	testImplementation "org.apache.groovy:groovy:$groovy4Version"
+	testImplementation "org.spockframework:spock-core:$spockVersion"
+
+	testRuntimeOnly "com.google.javascript:closure-compiler-unshaded:$closureCompilerVersion"
+	testRuntimeOnly "org.graalvm.js:js-community:$graalvmVersion"
+	testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
 
 publishing {

--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -174,7 +174,9 @@ def listConfigurationDependencies(Configuration configuration) {
 }
 
 test {
+	useJUnitPlatform()
 	testLogging {
+		events('passed', 'skipped', 'failed')
 		exceptionFormat = 'full'
 		showStandardStreams = true
 	}

--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -60,9 +60,9 @@ dependencies {
 	doc         'org.apache.groovy:groovy-all:4.0.22'
 	doc         'org.fusesource.jansi:jansi:1.11'
 	compileOnly     'org.mozilla:rhino:1.7R4'
-	compileOnly 	"org.graalvm.sdk:graal-sdk:22.0.0.2"
-	compileOnly 	"org.graalvm.js:js:22.0.0.2"
-	compileOnly 	"org.graalvm.js:js-scriptengine:22.0.0.2"
+	compileOnly 	"org.graalvm.sdk:graal-sdk:$graalvmVersion"
+	compileOnly 	"org.graalvm.js:js:$graalvmVersion"
+	compileOnly 	"org.graalvm.js:js-scriptengine:$graalvmVersion"
 	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20240317'
 	api 'org.slf4j:slf4j-api:1.7.28'
 	//api   'log4j:log4j:1.2.16'

--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 	doc         'org.fusesource.jansi:jansi:1.11'
 	compileOnly     'org.mozilla:rhino:1.7R4'
 	compileOnly 	"org.graalvm.sdk:graal-sdk:$graalvmVersion"
-	compileOnly 	"org.graalvm.js:js:$graalvmVersion"
+	compileOnly 	"org.graalvm.js:js-community:$graalvmVersion"
 	compileOnly 	"org.graalvm.js:js-scriptengine:$graalvmVersion"
 	compileOnly     'com.google.javascript:closure-compiler-unshaded:v20240317'
 	api 'org.slf4j:slf4j-api:1.7.28'

--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 	doc "org.apache.groovy:groovy:$groovy4Version"
 	doc "org.apache.groovy:groovy-ant:$groovy4Version"
 	doc "org.apache.groovy:groovy-templates:$groovy4Version"
-    doc "com.github.javaparser:javaparser-core:$javaparserVersion"
+	doc "com.github.javaparser:javaparser-core:$javaparserVersion"
 
 	// Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
 	compileOnly "com.google.javascript:closure-compiler-unshaded:$closureCompilerVersion"

--- a/asset-pipeline-core/src/test/groovy/asset/pipeline/CssAssetFileSpec.groovy
+++ b/asset-pipeline-core/src/test/groovy/asset/pipeline/CssAssetFileSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ class CssAssetFileSpec extends Specification {
           def cssFile = new CssAssetFile()
      when:
         def matches = (line =~ cssFile.directivePattern)?.collect{ it[1].trim()} ?: []
-        def match = matches.size > 0 ? matches[0] : null
+        def match = matches.size() > 0 ? matches[0] : null
     then:
       directive == match
     where:

--- a/asset-pipeline-core/src/test/groovy/asset/pipeline/HtmlAssetFileSpec.groovy
+++ b/asset-pipeline-core/src/test/groovy/asset/pipeline/HtmlAssetFileSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ class HtmlAssetFileSpec extends Specification {
      		def htmlFile = new HtmlAssetFile()
          when:
             def matches = (line =~ htmlFile.directivePattern)?.collect{ it[1].trim()} ?: []
-            def match = matches.size > 0 ? matches[0] : null
+            def match = matches.size() > 0 ? matches[0] : null
         then:
             directive == match
  		where:

--- a/asset-pipeline-core/src/test/groovy/asset/pipeline/JsAssetFileSpec.groovy
+++ b/asset-pipeline-core/src/test/groovy/asset/pipeline/JsAssetFileSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ class JsAssetFileSpec extends Specification {
      		def jsFile = new JsAssetFile()
          when:
             def matches = (line =~ jsFile.directivePattern)?.collect{ it[1].trim()} ?: []
-            def match = matches.size > 0 ? matches[0] : null
+            def match = matches.size() > 0 ? matches[0] : null
         then:
  			directive ==  match
  		where:

--- a/asset-pipeline-docs/build.gradle
+++ b/asset-pipeline-docs/build.gradle
@@ -1,27 +1,32 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-    }
-}
-
 plugins {
-    id 'org.asciidoctor.jvm.convert' version '4.0.2'
+    id 'org.asciidoctor.jvm.convert' version '4.0.4'
 }
 
-asciidoctor { 
-    outputDir = new File("$buildDir/docs")
+repositories {
+    mavenCentral()
+}
+
+asciidoctor {
+    baseDir = layout.projectDirectory.dir('src/asciidoc')
+    sourceDir = layout.projectDirectory.dir('src/asciidoc')
+    outputDir = layout.buildDirectory.dir('docs')
+    sources {
+        include 'index.adoc'
+    }
+    jvm {
+        jvmArgs += [
+            '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.io=ALL-UNNAMED'
+        ]
+    }
     options = [
         doctype: 'book'
-        
     ]
     attributes = [
-            'source-highlighter': 'coderay',
-            toc                 : 'left',
-            'toc-title': 'Table of Contents',
-            idprefix            : '',
-            idseparator         : '-'
-     ]
+        'source-highlighter': 'coderay',
+        toc                 : 'left',
+        'toc-title': 'Table of Contents',
+        idprefix            : '',
+        idseparator         : '-'
+    ]
 }

--- a/asset-pipeline-docs/build.gradle
+++ b/asset-pipeline-docs/build.gradle
@@ -19,10 +19,9 @@ asciidoctor {
             '--add-opens', 'java.base/java.io=ALL-UNNAMED'
         ]
     }
-    options = [
-        doctype: 'book'
-    ]
     attributes = [
+        doctype: 'book',
+        icons: 'font',
         'source-highlighter': 'coderay',
         toc                 : 'left',
         'toc-title': 'Table of Contents',

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -102,13 +102,6 @@ task(console, dependsOn: 'classes', type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 }
 
-test {
-    testLogging {
-        exceptionFormat = 'full'
-        showStandardStreams = true
-    }
-}
-
 // The configuration example below shows the minimum required properties
 // configured to publish your plugin to the plugin portal
 pluginBundle {

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
-	repositories {
-		mavenLocal()
-		mavenCentral()
-		maven {
-			url 'https://plugins.gradle.org/m2/'
-		}
-	}
-	dependencies {
-		classpath 'com.gradle.publish:plugin-publish-plugin:0.15.0'
-	}
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
+    dependencies {
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.15.0'
+    }
 }
 
 apply plugin: 'com.gradle.plugin-publish'
@@ -24,8 +24,8 @@ targetCompatibility = '1.17'
 ext.isReleaseVersion = !version.endsWith('SNAPSHOT')
 
 repositories {
-	mavenLocal()
-	mavenCentral()
+    mavenLocal()
+    mavenCentral()
 }
 
 java {
@@ -34,57 +34,57 @@ java {
 }
 
 dependencies {
-	api gradleApi()
-	//api localGroovy()
-	compileOnly    'org.codehaus.groovy:groovy:3.0.20'
-	api(project(':asset-pipeline-core')) {
-		exclude module:'groovy'
-		exclude module:'groovy-all'
-	}
-	api 'com.google.javascript:closure-compiler-unshaded:v20240317'
+    api gradleApi()
+    //api localGroovy()
+    compileOnly    'org.codehaus.groovy:groovy:3.0.20'
+    api(project(':asset-pipeline-core')) {
+        exclude module:'groovy'
+        exclude module:'groovy-all'
+    }
+    api 'com.google.javascript:closure-compiler-unshaded:v20240317'
     api "org.graalvm.sdk:graal-sdk:$graalvmVersion"
     api("org.graalvm.js:js:$graalvmVersion") {
-    	exclude group:'org.graalvm.js', module:'js-community'
+        exclude group:'org.graalvm.js', module:'js-community'
     }
     api "org.graalvm.js:js-language:$graalvmVersion"
     api "org.graalvm.js:js-scriptengine:$graalvmVersion"
-	testImplementation('org.spockframework:spock-core:1.3-groovy-2.4')
+    testImplementation('org.spockframework:spock-core:1.3-groovy-2.4')
 }
 
 publishing {
-	publications {
-		maven(MavenPublication) {
-			artifactId 'asset-pipeline-gradle'
-			pom.withXml {
-				asNode().children().last() + {
-					resolveStrategy = Closure.DELEGATE_FIRST
-					name 'asset-pipeline-gradle'
-					description 'JVM Asset Pipeline Gradle Adapter.'
-					url 'https://github.com/bertramdev/asset-pipeline-core'
-					scm {
-						url 'https://github.com/bertramdev/asset-pipeline-core'
-						connection 'scm:https://bertramdev@github.com/bertramdev/asset-pipeline-core.git'
-						developerConnection 'scm:git://github.com/bertramdev/asset-pipeline-core.git'
-					}
-					licenses {
-						license {
-							name 'The Apache Software License, Version 2.0'
-							url 'http://www.apache.org/license/LICENSE-2.0.txt'
-							distribution 'repo'
-						}
-					}
-					developers {
-						developer {
-							id 'davydotcom'
-							name 'David Estes'
-							email 'davydotcom@gmail.com'
-						}
-					}
-				}
-			}
-			from components.java
-		}
-	}
+    publications {
+        maven(MavenPublication) {
+            artifactId 'asset-pipeline-gradle'
+            pom.withXml {
+                asNode().children().last() + {
+                    resolveStrategy = Closure.DELEGATE_FIRST
+                    name 'asset-pipeline-gradle'
+                    description 'JVM Asset Pipeline Gradle Adapter.'
+                    url 'https://github.com/bertramdev/asset-pipeline-core'
+                    scm {
+                        url 'https://github.com/bertramdev/asset-pipeline-core'
+                        connection 'scm:https://bertramdev@github.com/bertramdev/asset-pipeline-core.git'
+                        developerConnection 'scm:git://github.com/bertramdev/asset-pipeline-core.git'
+                    }
+                    licenses {
+                        license {
+                            name 'The Apache Software License, Version 2.0'
+                            url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                            distribution 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id 'davydotcom'
+                            name 'David Estes'
+                            email 'davydotcom@gmail.com'
+                        }
+                    }
+                }
+            }
+            from components.java
+        }
+    }
 
     repositories {
         maven {
@@ -101,37 +101,33 @@ publishing {
     }
 }
 
-
-
-
 task(console, dependsOn: 'classes', type: JavaExec) {
-main = 'groovy.ui.Console'
-classpath = sourceSets.main.runtimeClasspath
+    main = 'groovy.ui.Console'
+    classpath = sourceSets.main.runtimeClasspath
 }
 
 test {
-	testLogging {
-		exceptionFormat = 'full'
-		showStandardStreams = true
-	}
+    testLogging {
+        exceptionFormat = 'full'
+        showStandardStreams = true
+    }
 }
 
 // The configuration example below shows the minimum required properties
 // configured to publish your plugin to the plugin portal
 pluginBundle {
-	website = 'https://github.com/bertramdev/asset-pipeline-core/'
-	vcsUrl = 'https://github.com/bertramdev/asset-pipeline-core/'
-	description = 'JVM Asset Pipeline Gradle Adapter.'
-	tags = ['assets', 'resources', 'asset-pipeline']
+    website = 'https://github.com/bertramdev/asset-pipeline-core/'
+    vcsUrl = 'https://github.com/bertramdev/asset-pipeline-core/'
+    description = 'JVM Asset Pipeline Gradle Adapter.'
+    tags = ['assets', 'resources', 'asset-pipeline']
 
-	plugins {
-		assetPipelinePlugin {
-			id = 'com.bertramlabs.asset-pipeline'
-			displayName = 'Asset-Pipeline Plugin'
-		}
-	}
-	mavenCoordinates {
-		groupId = 'com.bertramlabs.plugins'
-	}
+    plugins {
+        assetPipelinePlugin {
+            id = 'com.bertramlabs.asset-pipeline'
+            displayName = 'Asset-Pipeline Plugin'
+        }
+    }
+    mavenCoordinates {
+        groupId = 'com.bertramlabs.plugins'
+    }
 }
-

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -42,9 +42,9 @@ dependencies {
 		exclude module:'groovy-all'
 	}
 	api 'com.google.javascript:closure-compiler-unshaded:v20240317'
-	api("org.graalvm.sdk:graal-sdk:22.0.0.2")
-    api("org.graalvm.js:js:22.0.0.2")
-    api("org.graalvm.js:js-scriptengine:22.0.0.2")
+    api "org.graalvm.sdk:graal-sdk:$graalvmVersion"
+    api "org.graalvm.js:js:$graalvmVersion"
+    api "org.graalvm.js:js-scriptengine:$graalvmVersion"
 	testImplementation('org.spockframework:spock-core:1.3-groovy-2.4')
 }
 

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -34,18 +34,17 @@ java {
 }
 
 dependencies {
-    api gradleApi()
-    //api localGroovy()
-    compileOnly    'org.codehaus.groovy:groovy:3.0.20'
-    api(project(':asset-pipeline-core')) {
-        exclude module:'groovy'
-        exclude module:'groovy-all'
-    }
-    api 'com.google.javascript:closure-compiler-unshaded:v20240317'
-    api "org.graalvm.sdk:graal-sdk:$graalvmVersion"
-    api "org.graalvm.js:js-community:$graalvmVersion"
-    api "org.graalvm.js:js-scriptengine:$graalvmVersion"
-    testImplementation('org.spockframework:spock-core:1.3-groovy-2.4')
+
+    implementation gradleApi()
+    implementation project(':asset-pipeline-core')
+
+    // Gradle Plugin must be compiled with Groovy 3
+    compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+
+    // These will be used by the Asset Pipeline Gradle Plugin for pre-compiling assets
+    // and when running bootRun task (in development)
+    runtimeOnly "com.google.javascript:closure-compiler-unshaded:$closureCompilerVersion"
+    runtimeOnly "org.graalvm.js:js-community:$graalvmVersion"
 }
 
 publishing {

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -43,10 +43,7 @@ dependencies {
     }
     api 'com.google.javascript:closure-compiler-unshaded:v20240317'
     api "org.graalvm.sdk:graal-sdk:$graalvmVersion"
-    api("org.graalvm.js:js:$graalvmVersion") {
-        exclude group:'org.graalvm.js', module:'js-community'
-    }
-    api "org.graalvm.js:js-language:$graalvmVersion"
+    api "org.graalvm.js:js-community:$graalvmVersion"
     api "org.graalvm.js:js-scriptengine:$graalvmVersion"
     testImplementation('org.spockframework:spock-core:1.3-groovy-2.4')
 }

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -43,7 +43,10 @@ dependencies {
 	}
 	api 'com.google.javascript:closure-compiler-unshaded:v20240317'
     api "org.graalvm.sdk:graal-sdk:$graalvmVersion"
-    api "org.graalvm.js:js:$graalvmVersion"
+    api("org.graalvm.js:js:$graalvmVersion") {
+    	exclude group:'org.graalvm.js', module:'js-community'
+    }
+    api "org.graalvm.js:js-language:$graalvmVersion"
     api "org.graalvm.js:js-scriptengine:$graalvmVersion"
 	testImplementation('org.spockframework:spock-core:1.3-groovy-2.4')
 }

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -169,7 +169,7 @@ class AssetPipelinePlugin implements Plugin<Project> {
             if (buildDependencies) {
                 for (file in buildDependencies) {
                     if (file.name.startsWith('graal') || file.name.startsWith('js') || file.name.startsWith('rhino-') || file.name.startsWith('closure-compiler-unshaded-')) {
-                        project.getLogger().info("Adding build dependency ${file} to bootRun")
+                        project.getLogger().info("asset-pipeline: Adding build dependency ${file} to bootRun")
                         additionalFiles.add(file)
                     }
                 }
@@ -177,7 +177,7 @@ class AssetPipelinePlugin implements Plugin<Project> {
             def assetDeps = project.configurations.findByName(ASSET_CONFIGURATION_NAME)?.files
             if (assetDeps) {
                 for (file in assetDeps) {
-                    project.getLogger().info("Adding asset dependency ${file} to bootRun")
+                    project.getLogger().info("asset-pipeline: Adding asset dependency ${file} to bootRun")
                     additionalFiles.add(file)
                 }
             }

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 the original author or authors.
+* Copyright 2014-2025 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,9 +19,6 @@ package asset.pipeline.gradle
 import asset.pipeline.AssetPipelineConfigHolder
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.UnknownDomainObjectException
-import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.plugins.JavaPlugin
@@ -58,136 +55,106 @@ class AssetPipelinePlugin implements Plugin<Project> {
         }
         defaultConfiguration.compileDir = "${project.buildDir}/assets"
 
-        project.tasks.create('assetCompile', AssetCompile)
-        project.tasks.create('assetPluginPackage', AssetPluginPackage)
+        project.tasks.register('assetCompile', AssetCompile)
+        project.tasks.register('assetPluginPackage', AssetPluginPackage)
 
-
-        def assetPrecompileTask = project.tasks.getByName('assetCompile')
-        def assetPluginTask = project.tasks.getByName('assetPluginPackage')
-        // assetPrecompileTask.dependsOn('classes')
-        def assetCleanTask = project.tasks.create('assetClean', Delete)
-        project.configurations.create("assetDevelopmentRuntime")
-        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.sdk:graal-sdk:$graalvmVersion")
-        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js-community:$graalvmVersion")
-        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js-scriptengine:$graalvmVersion")
+        def assetPrecompileTask = project.tasks.named('assetCompile', AssetCompile)
+        def assetPluginTask = project.tasks.named('assetPluginPackage', AssetPluginPackage)
+        def assetCleanTask = project.tasks.register('assetClean', Delete)
+        project.configurations.create(ASSET_DEVELOPMENT_CONFIGURATION_NAME)
 
         project.afterEvaluate {
             def assetPipeline = project.extensions.getByType(AssetPipelineExtensionImpl)
-            ProcessResources processResources
-            DistributionContainer distributionContainer
-            processResources = (ProcessResources) project.tasks.findByName('processResources')
-            try {
-                distributionContainer = project.extensions.getByType(DistributionContainer)
-            } catch(UnknownDomainObjectException ex) {
-                //we dont care this is just to see if it exists
-            }
+            def distributionContainer = project.extensions.findByType(DistributionContainer)
+            def processResources = project.tasks.named('processResources', ProcessResources)
 
             assetCleanTask.configure {
                 delete project.file(assetPipeline.compileDir)
             }
             def configDestinationDir = project.file(assetPipeline.compileDir)
 
-
-
             assetPluginTask.configure {
-                assetsDir = project.file(assetPipeline.assetsPath)
-                destinationDir = project.file("${processResources?.destinationDir}/META-INF")
+                it.with {
+                    assetsDir = project.file(assetPipeline.assetsPath)
+                    destinationDir = project.file("${processResources.get().destinationDir}/META-INF")
+                }
             }
 
             assetPrecompileTask.configure {
-                destinationDir = configDestinationDir
-                assetsDir = project.file(assetPipeline.assetsPath)
-                minifyJs = assetPipeline.minifyJs
-                minifyCss = assetPipeline.minifyCss
-                minifyOptions = assetPipeline.minifyOptions
-                includes = assetPipeline.includes
-                excludes = assetPipeline.excludes
-                excludesGzip = assetPipeline.excludesGzip
-                configOptions = assetPipeline.configOptions
-                skipNonDigests = assetPipeline.skipNonDigests
-                enableDigests = assetPipeline.enableDigests
-                enableSourceMaps = assetPipeline.enableSourceMaps
-                resolvers = assetPipeline.resolvers
-                enableGzip = assetPipeline.enableGzip
-                verbose = assetPipeline.verbose
-                maxThreads = assetPipeline.maxThreads
+                it.with {
+                    destinationDir = configDestinationDir
+                    assetsDir = project.file(assetPipeline.assetsPath)
+                    minifyJs = assetPipeline.minifyJs
+                    minifyCss = assetPipeline.minifyCss
+                    minifyOptions = assetPipeline.minifyOptions
+                    includes = assetPipeline.includes
+                    excludes = assetPipeline.excludes
+                    excludesGzip = assetPipeline.excludesGzip
+                    configOptions = assetPipeline.configOptions
+                    skipNonDigests = assetPipeline.skipNonDigests
+                    enableDigests = assetPipeline.enableDigests
+                    enableSourceMaps = assetPipeline.enableSourceMaps
+                    resolvers = assetPipeline.resolvers
+                    enableGzip = assetPipeline.enableGzip
+                    verbose = assetPipeline.verbose
+                    maxThreads = assetPipeline.maxThreads
+                }
             }
 
             configureBootRun(project)
 
-            if(distributionContainer) {
-                distributionContainer.getByName("main").contents.from(assetPipeline.compileDir) {
-                    into "app/assets"
+            if (distributionContainer) {
+                distributionContainer.named('main').configure {
+                    it.with {
+                        contents.from(assetPipeline.compileDir) {
+                            into('app/assets')
+                        }
+                    }
                 }
             }
 
-            if (assetPipeline.packagePlugin) { //this is just a lib we dont want to do assetCompile
-                processResources.dependsOn(assetPluginTask)
-            } else if(assetPipeline.developmentRuntime == false && processResources) {
-                processResources.dependsOn(assetPrecompileTask)
-                processResources.from assetPipeline.compileDir, {
-                    into "assets"
+            if (assetPipeline.packagePlugin) { // If this is just a lib, we don't want to do assetCompile
+                processResources.configure {
+                    it.dependsOn(assetPluginTask)
                 }
-            } else {
-                if (assetPipeline.jarTaskName) {
-                    Jar jarTask = project.tasks.findByName(assetPipeline.jarTaskName)
-                    if (jarTask) {
-                        jarTask.dependsOn assetPrecompileTask
-                        jarTask.from assetPipeline.compileDir, {
-                            into "assets"
+            } else if(!assetPipeline.developmentRuntime && processResources) {
+                processResources.configure {
+                    it.with {
+                        dependsOn(assetPrecompileTask)
+                        from(assetPipeline.compileDir) {
+                            into('assets')
                         }
                     }
-                } else { //no jar task name specified we need to try and infer
-                    def assetTasks = ['war', 'shadowJar', 'jar', 'bootWar','bootJar']
-
-                    assetTasks?.each { taskName ->
-                        try {
-                            Jar jarTask = project.tasks.findByName(taskName)
-                            if (jarTask) {
-                                jarTask.dependsOn assetPrecompileTask
-                                jarTask.from assetPipeline.compileDir, {
-                                    into "assets"
-                                }
-                            }
-                        } catch(UnknownTaskException ex) {
-                            // if task doesnt exist no worries
+                }
+            } else {
+                def assetTasks = [assetPipeline.jarTaskName, 'war', 'shadowJar', 'jar', 'bootWar', 'bootJar']
+                project.tasks.withType(Jar).matching { it.name in assetTasks }.configureEach {
+                    it.with {
+                        dependsOn(assetPrecompileTask)
+                        from(assetPipeline.compileDir) {
+                            into('assets')
                         }
-
                     }
                 }
             }
         }
-
-
     }
 
     private void configureBootRun(Project project) {
-        project.getPlugins().withId("org.springframework.boot", plugin -> {
-            project.getTasks().named("bootRun", Task.class, bootRun -> {
-                String version = AssetPipelinePlugin.class.getPackage().getImplementationVersion()
-                project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME, "com.bertramlabs.plugins:asset-pipeline-gradle:${version}")
-                project.getLogger().info("asset-pipeline: Adding ${ASSET_DEVELOPMENT_CONFIGURATION_NAME} configuration to bootRun classPath")
-                bootRun.setClasspath(bootRun.getClasspath().plus(project.getConfigurations().maybeCreate(ASSET_DEVELOPMENT_CONFIGURATION_NAME)))
-                project.getLogger().info("asset-pipeline: Adding ${ASSET_CONFIGURATION_NAME} configuration to bootRun classPath")
-                bootRun.setClasspath(bootRun.getClasspath().plus(project.getConfigurations().maybeCreate(ASSET_CONFIGURATION_NAME)))
+        project.plugins.withId('org.springframework.boot', { Plugin plugin ->
+            project.tasks.named('bootRun', JavaExec,{ JavaExec bootRun ->
+                String version = AssetPipelinePlugin.package.implementationVersion
+                project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME, "com.bertramlabs.plugins:asset-pipeline-gradle:$version")
+                project.logger.info('asset-pipeline: Adding {} configuration to bootRun classPath', ASSET_DEVELOPMENT_CONFIGURATION_NAME)
+                bootRun.classpath += project.configurations.maybeCreate(ASSET_DEVELOPMENT_CONFIGURATION_NAME)
+                project.logger.info('asset-pipeline: Adding {} configuration to bootRun classPath', ASSET_CONFIGURATION_NAME)
+                bootRun.classpath += project.configurations.maybeCreate(ASSET_CONFIGURATION_NAME)
             })
         })
     }
 
     private void createGradleConfiguration(Project project) {
-        Configuration configuration = project.configurations.create(ASSET_CONFIGURATION_NAME)
-        JavaExec bootRunTask = (JavaExec)project.tasks.findByName('bootRun')
-
-        project.plugins.withType(JavaPlugin) {
-            if(bootRunTask) {
-                Configuration runtimeConfiguration = project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
-                runtimeConfiguration.extendsFrom configuration        
-            } else {
-                Configuration runtimeConfiguration = project.configurations.getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME)
-                runtimeConfiguration.extendsFrom configuration        
-            }
-            
-        }
+        Configuration assetsConfiguration = project.configurations.create(ASSET_CONFIGURATION_NAME)
+        project.configurations.getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME).extendsFrom(assetsConfiguration)
     }
-
 }

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -68,9 +68,9 @@ class AssetPipelinePlugin implements Plugin<Project> {
         // assetPrecompileTask.dependsOn('classes')
         def assetCleanTask = project.tasks.create('assetClean', Delete)
         project.configurations.create("assetDevelopmentRuntime")
-        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.sdk:graal-sdk:22.0.0.2")
-        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js:22.0.0.2")
-        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js-scriptengine:22.0.0.2")
+        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.sdk:graal-sdk:$graalvmVersion")
+        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js:$graalvmVersion")
+        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js-scriptengine:$graalvmVersion")
 
         project.afterEvaluate {
             def assetPipeline = project.extensions.getByType(AssetPipelineExtensionImpl)

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -117,7 +117,7 @@ class AssetPipelinePlugin implements Plugin<Project> {
                 processResources.configure {
                     it.dependsOn(assetPluginTask)
                 }
-            } else if(!assetPipeline.developmentRuntime && processResources) {
+            } else if (!assetPipeline.developmentRuntime && processResources) {
                 processResources.configure {
                     it.with {
                         dependsOn(assetPrecompileTask)
@@ -141,16 +141,16 @@ class AssetPipelinePlugin implements Plugin<Project> {
     }
 
     private void configureBootRun(Project project) {
-        project.plugins.withId('org.springframework.boot', { Plugin plugin ->
-            project.tasks.named('bootRun', JavaExec,{ JavaExec bootRun ->
+        project.plugins.withId('org.springframework.boot') { Plugin plugin ->
+            project.tasks.named('bootRun', JavaExec) { JavaExec bootRun ->
                 String version = AssetPipelinePlugin.package.implementationVersion
                 project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME, "com.bertramlabs.plugins:asset-pipeline-gradle:$version")
                 project.logger.info('asset-pipeline: Adding {} configuration to bootRun classPath', ASSET_DEVELOPMENT_CONFIGURATION_NAME)
                 bootRun.classpath += project.configurations.maybeCreate(ASSET_DEVELOPMENT_CONFIGURATION_NAME)
                 project.logger.info('asset-pipeline: Adding {} configuration to bootRun classPath', ASSET_CONFIGURATION_NAME)
                 bootRun.classpath += project.configurations.maybeCreate(ASSET_CONFIGURATION_NAME)
-            })
-        })
+            }
+        }
     }
 
     private void createGradleConfiguration(Project project) {

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -52,7 +52,6 @@ class AssetPipelinePlugin implements Plugin<Project> {
         def config = AssetPipelineConfigHolder.config != null ? AssetPipelineConfigHolder.config : [:]
         config.cacheLocation = "${project.buildDir}/.assetcache"
         if (project.extensions.findByName('grails')) {
-            
             defaultConfiguration.assetsPath = 'grails-app/assets'
         } else {
             defaultConfiguration.assetsPath = "${project.projectDir}/src/assets"
@@ -69,7 +68,7 @@ class AssetPipelinePlugin implements Plugin<Project> {
         def assetCleanTask = project.tasks.create('assetClean', Delete)
         project.configurations.create("assetDevelopmentRuntime")
         // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.sdk:graal-sdk:$graalvmVersion")
-        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js:$graalvmVersion")
+        // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js-community:$graalvmVersion")
         // project.dependencies.add(ASSET_DEVELOPMENT_CONFIGURATION_NAME,"org.graalvm.js:js-scriptengine:$graalvmVersion")
 
         project.afterEvaluate {

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -164,27 +164,25 @@ class AssetPipelinePlugin implements Plugin<Project> {
     private void configureBootRun(Project project) {
         JavaExec bootRunTask = (JavaExec)project.tasks.findByName('bootRun')
         if (bootRunTask != null) {
-            
-
-    
             List additionalFiles = []
             def buildDependencies = project.buildscript.configurations.findByName("classpath")?.files
             if (buildDependencies) {
                 for (file in buildDependencies) {
                     if (file.name.startsWith('graal') || file.name.startsWith('js') || file.name.startsWith('rhino-') || file.name.startsWith('closure-compiler-unshaded-')) {
+                        project.getLogger().info("Adding build dependency ${file} to bootRun")
                         additionalFiles.add(file)
                     }
                 }
             }
             def assetDeps = project.configurations.findByName(ASSET_CONFIGURATION_NAME)?.files
-            if(assetDeps) {
-                for(file in assetDeps) {
+            if (assetDeps) {
+                for (file in assetDeps) {
+                    project.getLogger().info("Adding asset dependency ${file} to bootRun")
                     additionalFiles.add(file)
                 }
             }
             bootRunTask.classpath += project.files(additionalFiles)
             // bootRunTask.classpath += project.files(project.configurations.findByName(ASSET_DEVELOPMENT_CONFIGURATION_NAME).files)
-
         }
     }
 

--- a/asset-pipeline-grails/build.gradle
+++ b/asset-pipeline-grails/build.gradle
@@ -153,7 +153,6 @@ dependencies {
     testImplementation("io.micronaut:micronaut-http-client")
 
 
-
     compileOnly "jakarta.servlet:jakarta.servlet-api:$servletApiVersion"
     compileOnly "jakarta.annotation:jakarta.annotation-api:$jakartaAnnotationApiVersion"
 

--- a/asset-pipeline-grails/build.gradle
+++ b/asset-pipeline-grails/build.gradle
@@ -50,25 +50,37 @@ repositories {
 configurations.configureEach {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if ((details.requested.group == 'org.codehaus.groovy' || details.requested.group == 'org.apache.groovy') && details.requested.name != 'groovy-bom') {
-            details.useTarget(group: 'org.apache.groovy', name: details.requested.name, version: "$groovyVersion")
+            details.useTarget(group: 'org.apache.groovy', name: details.requested.name, version: "$groovy4Version")
             details.because "The dependency coordinates are changed in Apache Groovy 4, plus ensure version"
         }
-
-        if (details.requested.group == "io.micronaut" && details.requested.name == "micronaut-inject-groovy") {
-            details.useVersion("$micronautVersion")
-        }
     }
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.grails:grails-bom:$grailsVersion"
-    }
-    applyMavenExclusions false
 }
 
 grails {
     packageAssets = false
+}
+
+dependencies {
+
+    implementation platform("org.grails:grails-bom:$grailsVersion")
+
+    implementation project(':asset-pipeline-core')
+    implementation 'org.grails:grails-plugin-url-mappings'
+
+    compileOnly 'com.github.ben-manes.caffeine:caffeine' // Cache
+    compileOnly 'jakarta.servlet:jakarta.servlet-api' // Provided by the servlet container
+    compileOnly 'org.grails:grails-core' // Provided as this is a Grails plugin
+    compileOnly 'org.grails:grails-web-taglib' // For taglib compilation
+
+    testImplementation 'org.grails:grails-web-testing-support'
+    testImplementation 'org.spockframework:spock-core'
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+    testLogging {
+        events('passed', 'skipped', 'failed')
+    }
 }
 
 publishing {
@@ -131,42 +143,6 @@ configurations.all {
     }
 }
 
-dependencies {
-    implementation("org.grails:grails-core")
-    implementation("org.grails:grails-logging")
-    // implementation("org.grails:grails-plugin-databinding")
-    // implementation("org.grails:grails-plugin-i18n")
-    // implementation("org.grails:grails-plugin-interceptors")
-    // implementation("org.grails:grails-plugin-rest")
-    // implementation("org.grails:grails-plugin-services")
-    implementation("org.grails:grails-plugin-url-mappings")
-    implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
-    implementation("org.grails:grails-web-boot")
-    implementation("org.springframework.boot:spring-boot-autoconfigure")
-    implementation("org.springframework.boot:spring-boot-starter-logging")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
-    compileOnly("io.micronaut:micronaut-inject-groovy")
-    
-    
-    testImplementation("io.micronaut:micronaut-inject-groovy")
-    testImplementation("org.spockframework:spock-core")
-    testImplementation("io.micronaut:micronaut-http-client")
-
-
-    compileOnly "jakarta.servlet:jakarta.servlet-api:$servletApiVersion"
-    compileOnly "jakarta.annotation:jakarta.annotation-api:$jakartaAnnotationApiVersion"
-
-    compileOnly 'org.grails:grails-web-taglib' // For taglib compilation
-
-    implementation project(':asset-pipeline-core'), {
-        exclude group:'org.mozilla', module:'rhino'
-        exclude group:'com.google.javascript', module:'closure-compiler-unshaded'
-    }
-    testImplementation('org.grails:grails-web-testing-support')
-    testImplementation "jakarta.servlet:jakarta.servlet-api:$servletApiVersion"
-    testImplementation "jakarta.annotation:jakarta.annotation-api:$jakartaAnnotationApiVersion"
-    // testCompile "org.grails:grails-plugin-testing"
-}
 
 bootRun {
     jvmArgs('-Dspring.output.ansi.enabled=always')

--- a/asset-pipeline-grails/build.gradle
+++ b/asset-pipeline-grails/build.gradle
@@ -9,7 +9,8 @@ buildscript {
         maven { url "https://repo.grails.org/grails/core" }
     }
     dependencies {
-        classpath "org.grails:grails-gradle-plugin:$grailsVersion"
+        classpath platform("org.grails:grails-bom:$grailsVersion")
+        classpath 'org.grails:grails-gradle-plugin'
     }
 }
 
@@ -132,19 +133,3 @@ publishing {
         }
     }
 }
-
-configurations.all {
-    resolutionStrategy.dependencySubstitution {
-        substitute module("org.codehaus.groovy:groovy") using module('org.apache.groovy:groovy:4.0.22')
-        substitute module("org.codehaus.groovy:groovy-templates") using module('org.apache.groovy:groovy-templates:4.0.22')
-        substitute module("org.codehaus.groovy:groovy-xml") using module('org.apache.groovy:groovy-xml:4.0.22')
-        substitute module("org.codehaus.groovy:groovy-json") using module('org.apache.groovy:groovy-json:4.0.22')
-        substitute module("org.codehaus.groovy:groovy-test-junit5") using module('org.apache.groovy:groovy-test-junit5:4.0.22')
-    }
-}
-
-
-bootRun {
-    jvmArgs('-Dspring.output.ansi.enabled=always')
-}
-

--- a/asset-pipeline-grails/build.gradle
+++ b/asset-pipeline-grails/build.gradle
@@ -156,6 +156,7 @@ dependencies {
     compileOnly "jakarta.servlet:jakarta.servlet-api:$servletApiVersion"
     compileOnly "jakarta.annotation:jakarta.annotation-api:$jakartaAnnotationApiVersion"
 
+    compileOnly 'org.grails:grails-web-taglib' // For taglib compilation
 
     implementation project(':asset-pipeline-core'), {
         exclude group:'org.mozilla', module:'rhino'

--- a/asset-pipeline-grails/gradle.properties
+++ b/asset-pipeline-grails/gradle.properties
@@ -1,10 +1,5 @@
 grailsVersion=7.0.0-SNAPSHOT
-groovyVersion=4.0.22
-micronautVersion=4.5.1
-jakartaAnnotationApiVersion=3.0.0
-caffeineVersion=3.1.8
-servletApiVersion=6.0.0
-commonsLang3Version:3.17.0
+
 websiteUrl=http://www.asset-pipeline.com
 issueTrackerUrl=https://github.com/bertramdev/grails-asset-pipeline/issues
 vcsUrl=https://github.com/bertramdev/grails-asset-pipeline

--- a/asset-pipeline-grails/grails-app/init/asset/pipeline/Application.groovy
+++ b/asset-pipeline-grails/grails-app/init/asset/pipeline/Application.groovy
@@ -1,8 +1,8 @@
 package asset.pipeline
 
-import grails.boot.*
+import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
-import grails.plugins.metadata.*
+import grails.plugins.metadata.PluginSource
 
 @PluginSource
 class Application extends GrailsAutoConfiguration {

--- a/asset-pipeline-grails/grails-app/init/asset/pipeline/AssetPipelineBootStrap.groovy
+++ b/asset-pipeline-grails/grails-app/init/asset/pipeline/AssetPipelineBootStrap.groovy
@@ -1,13 +1,13 @@
 package asset.pipeline
 
-import asset.pipeline.AssetPipelineConfigHolder
+import grails.core.GrailsApplication
 
 class AssetPipelineBootStrap {
 
-    def grailsApplication
+    GrailsApplication grailsApplication
 
-    def init = { servletContext ->
-        def storagePath = grailsApplication.config.getProperty('grails.assets.storagePath')
+    def init = {
+        def storagePath = grailsApplication.config.getProperty('grails.assets.storagePath', String)
         if (!storagePath) {
             return
         }
@@ -38,7 +38,7 @@ class AssetPipelineBootStrap {
                 }
             }
             def manifestFile = new File(storagePath,'manifest.properties')
-            manifest.store(manifestFile.newWriter(),"")
+            manifest.store(manifestFile.newWriter(), '')
         }
     }
 
@@ -70,12 +70,11 @@ class AssetPipelineBootStrap {
                 digestFile?.setReadable(true,false)
                 digestFile?.setExecutable(true,false)
                 digestFile?.setWritable(true)
-            } catch (ex) {
+            } catch (ignore) {
                // attempting permission set
             }
         } finally {
             sourceStream.close()
         }
-        
     }
 }

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -1,13 +1,10 @@
 package asset.pipeline
 
-
 import asset.pipeline.grails.AssetAttributes
 import asset.pipeline.grails.AssetProcessorService
 import asset.pipeline.grails.ProductionAssetCache
-import asset.pipeline.AssetHelper
-import asset.pipeline.AssetPipelineClassLoaderEntry
 import groovy.transform.CompileStatic
-import groovy.util.logging.Commons
+import groovy.util.logging.Slf4j
 import jakarta.servlet.FilterChain
 import jakarta.servlet.FilterConfig
 import jakarta.servlet.ServletContext
@@ -20,8 +17,7 @@ import org.springframework.core.io.Resource
 import org.springframework.web.context.support.WebApplicationContextUtils
 import org.springframework.web.filter.OncePerRequestFilter
 
-
-@Commons
+@Slf4j
 @CompileStatic
 class AssetPipelineFilter extends OncePerRequestFilter {
 

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,19 @@
  */
 package asset.pipeline
 
-import asset.pipeline.grails.AssetProcessorService
+import asset.pipeline.fs.ClasspathAssetResolver
+import asset.pipeline.fs.FileSystemAssetResolver
 import asset.pipeline.grails.AssetResourceLocator
-import asset.pipeline.grails.fs.*
-import asset.pipeline.fs.*
-import asset.pipeline.*
+import grails.plugins.Plugin
 import grails.util.BuildSettings
+import groovy.util.logging.Slf4j
 import org.grails.plugins.BinaryGrailsPlugin
 import org.grails.web.config.http.GrailsFilters
-import groovy.util.logging.Commons
 import org.springframework.util.ClassUtils
 
-@Commons
-class AssetPipelineGrailsPlugin extends grails.plugins.Plugin {
-    def grailsVersion   = "3.0 > *"
+@Slf4j
+class AssetPipelineGrailsPlugin extends Plugin {
+    def grailsVersion   = "7.0 > *"
     def title           = "Asset Pipeline Plugin"
     def author          = "David Estes"
     def authorEmail     = "destes@bcap.com"
@@ -42,7 +41,7 @@ class AssetPipelineGrailsPlugin extends grails.plugins.Plugin {
         "grails-app/assets/**",
         "test/dummy/**"
     ]
-    def developers      = [ [name: 'Brian Wheeler'] ]
+    def developers = [[name: 'Brian Wheeler']]
     def loadAfter = ['url-mappings']
 
     void doWithApplicationContext() {

--- a/asset-pipeline-servlet/build.gradle
+++ b/asset-pipeline-servlet/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
 test {
 	testLogging {
+		events('passed', 'skipped', 'failed')
 		exceptionFormat = 'full'
 		showStandardStreams = true
 	}

--- a/asset-pipeline-servlet/build.gradle
+++ b/asset-pipeline-servlet/build.gradle
@@ -40,19 +40,21 @@ java {
 }
 
 dependencies {
-	implementation    'org.apache.groovy:groovy:4.0.22'
-	//implementation    'org.apache.groovy:groovy:3.0.20'
-	api     project(':asset-pipeline-core')
-	api 'jakarta.servlet:jakarta.servlet-api:6.0.0'
-	testImplementation 'org.apache.groovy:groovy:2.4.19'
-    testImplementation 'org.eclipse.jetty:jetty-server:11.0.15'
-    testImplementation 'org.eclipse.jetty:jetty-servlet:11.0.15'
-    testImplementation 'org.eclipse.jetty:jetty-webapp:11.0.15'
-    testImplementation "org.apache.httpcomponents:httpclient:4.3.4"
-    testImplementation "org.apache.httpcomponents:fluent-hc:4.3.4"
-    testImplementation 'junit:junit:4.10'
-	compileOnly 'org.slf4j:slf4j-simple:2.0.5'
-	testImplementation 'org.slf4j:slf4j-simple:2.0.5'
+
+	api project(':asset-pipeline-core')
+
+	implementation "org.apache.groovy:groovy:$groovy4Version"
+
+	compileOnlyApi "jakarta.servlet:jakarta.servlet-api:$servletApiVersion"
+
+	testImplementation "org.apache.httpcomponents:fluent-hc:$fluentHcVersion"
+	testImplementation "org.apache.httpcomponents:httpcore:$httpcoreVersion"
+	testImplementation "junit:junit:$junit4Version"
+	testImplementation "org.eclipse.jetty:jetty-server:$jettyVersion"
+	testImplementation "org.eclipse.jetty:jetty-servlet:$jettyVersion"
+	testImplementation "org.eclipse.jetty:jetty-webapp:$jettyVersion"
+
+	testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
 
 test {

--- a/asset-pipeline-spring-boot/build.gradle
+++ b/asset-pipeline-spring-boot/build.gradle
@@ -112,10 +112,3 @@ task(console, dependsOn: 'classes', type: JavaExec) {
 	main = 'groovy.ui.Console'
 	classpath = sourceSets.main.runtimeClasspath
 }
-
-test {
-	testLogging {
-		exceptionFormat = 'full'
-		showStandardStreams = true
-	}
-}

--- a/asset-pipeline-spring-boot/build.gradle
+++ b/asset-pipeline-spring-boot/build.gradle
@@ -43,14 +43,18 @@ repositories {
 }
 
 dependencies {
-	compileOnly    'org.apache.groovy:groovy:4.0.22'
-	api     project(':asset-pipeline-core')
-	api     project(':asset-pipeline-servlet')
-	api     'org.springframework.boot:spring-boot-starter-web:3.0.0'
-	testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
-	// compileOnly "org.slf4j:log4j-over-slf4j:1.7.28"
 
+	api project(':asset-pipeline-core')
+	api project(':asset-pipeline-servlet')
 
+	implementation "org.springframework:spring-beans:$springVersion"
+	implementation "org.springframework:spring-context:$springVersion"
+	implementation "org.springframework:spring-core:$springVersion"
+	implementation "org.springframework:spring-web:$springVersion"
+	implementation "org.springframework.boot:spring-boot:$springBootVersion"
+
+	compileOnly "org.apache.groovy:groovy:$groovy4Version"
+	compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -99,9 +99,3 @@ subprojects { project ->
 
     }
 }
-test {
-    testLogging {
-        exceptionFormat = 'full'
-        showStandardStreams = true
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,14 @@ subprojects { project ->
 	            required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
 	            sign publishing.publications.maven
 	        }
+	        jar {
+	            manifest {
+	            	attributes(
+	            		'Implementation-Title': project.name,
+	            		'Implementation-Version': project.version
+	            	)
+	            }
+	        }
 	    }
 
 	    tasks.withType(Sign) {

--- a/build.gradle
+++ b/build.gradle
@@ -99,14 +99,6 @@ subprojects { project ->
 
     }
 }
-
-dependencies {
-    api 'org.apache.groovy:groovy:3.0.20'
-    api 'org.apache.groovy:groovy-templates:3.0.20'
-    api 'org.mozilla:rhino:1.7R4'
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
-}
-
 test {
     testLogging {
         exceptionFormat = 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -1,118 +1,115 @@
 buildscript {
-	repositories {
-		mavenLocal()
-		maven { url "https://plugins.gradle.org/m2/" }
-		mavenCentral()
-		
-	}
-	dependencies {
-		classpath "io.github.gradle-nexus:publish-plugin:1.3.0"
-	}
+    repositories {
+        mavenLocal()
+        maven { url "https://plugins.gradle.org/m2/" }
+        mavenCentral()
+
+    }
+    dependencies {
+        classpath "io.github.gradle-nexus:publish-plugin:1.3.0"
+    }
 }
 
 plugins {
-	id 'java'
-	id 'groovy'
-	id 'java-library'
+    id 'java'
+    id 'groovy'
+    id 'java-library'
     id 'signing'
     id 'idea'
     id 'maven-publish'
 }
-
 
 ext {
     isBuildSnapshot = version.endsWith('-SNAPSHOT')
     isReleaseVersion = !isBuildSnapshot
 }
 
-
 group = 'com.bertramlabs.plugins'
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 java {
-	withJavadocJar()
-	withSourcesJar()
+    withJavadocJar()
+    withSourcesJar()
 }
 
 if (isReleaseVersion) {
-   apply plugin: "io.github.gradle-nexus.publish-plugin"
-   nexusPublishing {
-       repositories {
-           sonatype {
-               if(project.hasProperty('mavenUser')) {
-                   username = mavenUser
-                   password = mavenPassword
-               }
-           }
-       }
-   }
+    apply plugin: "io.github.gradle-nexus.publish-plugin"
+    nexusPublishing {
+        repositories {
+            sonatype {
+                if(project.hasProperty('mavenUser')) {
+                    username = mavenUser
+                    password = mavenPassword
+                }
+            }
+        }
+    }
 } else {
-
-	publishing {
-		publications {
-			mavenJava(MavenPublication) {
-				from components.java
-			}
-		}
-		repositories {
-			maven {
-				url = project.hasProperty('labsNexusUrl') ? labsNexusUrl : "https://nexus.bertramlabs.com/content/repositories/snapshots"
-				if(project.hasProperty('labsNexusUser')) {
-					credentials {
-						username = labsNexusUser
-						password = labsNexusPassword
-					}
-				}
-			}
-		}
-	}
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+            }
+        }
+        repositories {
+            maven {
+                url = project.hasProperty('labsNexusUrl') ? labsNexusUrl : "https://nexus.bertramlabs.com/content/repositories/snapshots"
+                if(project.hasProperty('labsNexusUser')) {
+                    credentials {
+                        username = labsNexusUser
+                        password = labsNexusPassword
+                    }
+                }
+            }
+        }
+    }
 }
 
 subprojects { project ->
-	if (project.name != 'asset-pipeline-classpath-test' && project.name != 'asset-pipeline-docs' && project.name != 'asset-pipeline-site') {
-	    apply plugin: 'java'
-	    apply plugin: 'maven-publish'
-	    apply plugin: 'signing'
-	    afterEvaluate {
-	        signing {
-	            required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
-	            sign publishing.publications.maven
-	        }
-	        jar {
-	            manifest {
-	            	attributes(
-	            		'Implementation-Title': project.name,
-	            		'Implementation-Version': project.version
-	            	)
-	            }
-	        }
-	    }
+    if (project.name != 'asset-pipeline-classpath-test' && project.name != 'asset-pipeline-docs' && project.name != 'asset-pipeline-site') {
+        apply plugin: 'java'
+        apply plugin: 'maven-publish'
+        apply plugin: 'signing'
+        afterEvaluate {
+            signing {
+                required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
+                sign publishing.publications.maven
+            }
+            jar {
+                manifest {
+                    attributes(
+                            'Implementation-Title': project.name,
+                            'Implementation-Version': project.version
+                    )
+                }
+            }
+        }
 
-	    tasks.withType(Sign) {
-	        onlyIf { isReleaseVersion }
-	    }
+        tasks.withType(Sign) {
+            onlyIf { isReleaseVersion }
+        }
 
-	    //do not generate extra load on Nexus with new staging repository if signing fails
-	    tasks.withType(io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository).configureEach {
-	        shouldRunAfter(tasks.withType(Sign))
-	    }
-    
+        //do not generate extra load on Nexus with new staging repository if signing fails
+        tasks.withType(io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository).configureEach {
+            shouldRunAfter(tasks.withType(Sign))
+        }
+
     }
 }
 
 dependencies {
-	api 'org.apache.groovy:groovy:3.0.20'
-	api 'org.apache.groovy:groovy-templates:3.0.20'
-	api 'org.mozilla:rhino:1.7R4'
-	testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
+    api 'org.apache.groovy:groovy:3.0.20'
+    api 'org.apache.groovy:groovy-templates:3.0.20'
+    api 'org.mozilla:rhino:1.7R4'
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
 }
 
 test {
-	testLogging {
-		exceptionFormat = 'full'
-		showStandardStreams = true
-	}
+    testLogging {
+        exceptionFormat = 'full'
+        showStandardStreams = true
+    }
 }

--- a/coffee-asset-pipeline/build.gradle
+++ b/coffee-asset-pipeline/build.gradle
@@ -107,7 +107,9 @@ task(console, dependsOn: 'classes', type: JavaExec) {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
+        events('passed', 'skipped', 'failed')
         exceptionFormat = 'full'
         showStandardStreams = true
     }

--- a/coffee-asset-pipeline/build.gradle
+++ b/coffee-asset-pipeline/build.gradle
@@ -39,11 +39,15 @@ sourceSets {
 }
 
 dependencies {
-	api project(':asset-pipeline-core')
-	compileOnly 'org.apache.groovy:groovy:4.0.22'
-    api 'org.mozilla:rhino:1.7R4'
 
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    api project(':asset-pipeline-core')
+    api "org.mozilla:rhino:$rhinoVersion"
+
+    // Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
+    compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+
+    testImplementation "org.apache.groovy:groovy:$groovy4Version"
+    testImplementation "org.spockframework:spock-core:$spockVersion"
 }
 
 publishing {

--- a/ember-asset-pipeline/build.gradle
+++ b/ember-asset-pipeline/build.gradle
@@ -103,7 +103,9 @@ task(console, dependsOn: 'classes', type: JavaExec) {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
+        events('passed', 'skipped', 'failed')
         exceptionFormat = 'full'
         showStandardStreams = true
     }

--- a/ember-asset-pipeline/build.gradle
+++ b/ember-asset-pipeline/build.gradle
@@ -33,11 +33,17 @@ repositories {
 
 
 dependencies {
-	api project(':asset-pipeline-core')
-	api 'org.apache.groovy:groovy:4.0.22'
-    api 'org.mozilla:rhino:1.7R4'
 
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+	api project(':asset-pipeline-core')
+    api "org.mozilla:rhino:$rhinoVersion"
+
+    // Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
+    compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+
+    testImplementation "org.apache.groovy:groovy:$groovy4Version"
+    testImplementation "org.spockframework:spock-core:$spockVersion"
+
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
 
 publishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,25 @@
 version=5.0.6
+
+bootstrapCssVersion=5.3.3
+closureCompilerVersion=v20240317
+fluentHcVersion=4.5.14
 graalvmVersion=24.1.2
+# Core and plugins are compiled with Groovy 3 as they are used by the Gradle Plugin
+groovy3Version=3.0.23
+groovy4Version=4.0.25
+httpcoreVersion=4.4.16
+javaparserVersion=3.26.3
+javetVersion=1.1.0
+jettyVersion=11.0.24
+jsassVersion=5.11.1
+junit4Version=4.13.2
+less4jVersion=1.17.2
+less4jJsVersion=0.0.1
+rhinoVersion=1.8.0
+servletApiVersion=6.0.0
+slf4jVersion=2.0.16
+spockVersion=2.3-groovy-4.0
+springVersion=6.2.2
+springBootVersion=3.4.2
+
 org.gradle.warning.mode=none

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.0.5
+version=5.0.6
 graalvmVersion=24.1.2
 org.gradle.warning.mode=none

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
-version=5.0.6
+version=5.0.5
+graalvmVersion=22.0.0.2
 org.gradle.warning.mode=none

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=5.0.5
-graalvmVersion=22.0.0.2
+graalvmVersion=24.1.2
 org.gradle.warning.mode=none

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=5.0.5
+version=5.0.6
 org.gradle.warning.mode=none

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/handlebars-asset-pipeline/build.gradle
+++ b/handlebars-asset-pipeline/build.gradle
@@ -43,15 +43,15 @@ dependencies {
 	api project(':asset-pipeline-core')
     compileOnly 'org.apache.groovy:groovy-all:4.0.22'
     compileOnly 'org.mozilla:rhino:1.7R4'
-    compileOnly("org.graalvm.sdk:graal-sdk:22.0.0.2")
-    compileOnly("org.graalvm.js:js:22.0.0.2")
-    compileOnly("org.graalvm.js:js-scriptengine:22.0.0.2")
+    compileOnly("org.graalvm.sdk:graal-sdk:$graalvmVersion")
+    compileOnly("org.graalvm.js:js:$graalvmVersion")
+    compileOnly("org.graalvm.js:js-scriptengine:$graalvmVersion")
     // api 'log4j:log4j:1.2.17'
 
     testImplementation 'org.mozilla:rhino:1.7R4'
-    testImplementation("org.graalvm.sdk:graal-sdk:22.0.0.2")
-    testImplementation("org.graalvm.js:js:22.0.0.2")
-    testImplementation("org.graalvm.js:js-scriptengine:22.0.0.2")
+    testImplementation("org.graalvm.sdk:graal-sdk:$graalvmVersion")
+    testImplementation("org.graalvm.js:js:$graalvmVersion")
+    testImplementation("org.graalvm.js:js-scriptengine:$graalvmVersion")
     testImplementation 'org.apache.groovy:groovy-all:4.0.22'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
 }

--- a/handlebars-asset-pipeline/build.gradle
+++ b/handlebars-asset-pipeline/build.gradle
@@ -43,15 +43,15 @@ dependencies {
 	api project(':asset-pipeline-core')
     compileOnly 'org.apache.groovy:groovy-all:4.0.22'
     compileOnly 'org.mozilla:rhino:1.7R4'
-    compileOnly("org.graalvm.sdk:graal-sdk:$graalvmVersion")
-    compileOnly("org.graalvm.js:js:$graalvmVersion")
-    compileOnly("org.graalvm.js:js-scriptengine:$graalvmVersion")
+    compileOnly "org.graalvm.sdk:graal-sdk:$graalvmVersion"
+    compileOnly "org.graalvm.js:js-community:$graalvmVersion"
+    compileOnly "org.graalvm.js:js-scriptengine:$graalvmVersion"
     // api 'log4j:log4j:1.2.17'
 
     testImplementation 'org.mozilla:rhino:1.7R4'
-    testImplementation("org.graalvm.sdk:graal-sdk:$graalvmVersion")
-    testImplementation("org.graalvm.js:js:$graalvmVersion")
-    testImplementation("org.graalvm.js:js-scriptengine:$graalvmVersion")
+    testImplementation "org.graalvm.sdk:graal-sdk:$graalvmVersion"
+    testImplementation "org.graalvm.js:js-community:$graalvmVersion"
+    testImplementation "org.graalvm.js:js-scriptengine:$graalvmVersion"
     testImplementation 'org.apache.groovy:groovy-all:4.0.22'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
 }

--- a/handlebars-asset-pipeline/build.gradle
+++ b/handlebars-asset-pipeline/build.gradle
@@ -40,20 +40,20 @@ sourceSets {
 }
 
 dependencies {
-	api project(':asset-pipeline-core')
-    compileOnly 'org.apache.groovy:groovy-all:4.0.22'
-    compileOnly 'org.mozilla:rhino:1.7R4'
-    compileOnly "org.graalvm.sdk:graal-sdk:$graalvmVersion"
-    compileOnly "org.graalvm.js:js-community:$graalvmVersion"
-    compileOnly "org.graalvm.js:js-scriptengine:$graalvmVersion"
-    // api 'log4j:log4j:1.2.17'
 
-    testImplementation 'org.mozilla:rhino:1.7R4'
-    testImplementation "org.graalvm.sdk:graal-sdk:$graalvmVersion"
+	api project(':asset-pipeline-core')
+
+    // Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
+    compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+    compileOnly "org.codehaus.groovy:groovy-templates:$groovy3Version"
+    compileOnly "org.graalvm.polyglot:polyglot:$graalvmVersion"
+
+    testImplementation "org.apache.groovy:groovy:$groovy4Version"
     testImplementation "org.graalvm.js:js-community:$graalvmVersion"
-    testImplementation "org.graalvm.js:js-scriptengine:$graalvmVersion"
-    testImplementation 'org.apache.groovy:groovy-all:4.0.22'
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    testImplementation "org.spockframework:spock-core:$spockVersion"
+
+    testRuntimeOnly "org.apache.groovy:groovy-templates:$groovy4Version"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
 
 publishing {

--- a/handlebars-asset-pipeline/build.gradle
+++ b/handlebars-asset-pipeline/build.gradle
@@ -112,7 +112,9 @@ task(console, dependsOn: 'classes', type: JavaExec) {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
+        events('passed', 'skipped', 'failed')
         exceptionFormat = 'full'
         showStandardStreams = true
     }

--- a/jsx-asset-pipeline/build.gradle
+++ b/jsx-asset-pipeline/build.gradle
@@ -100,7 +100,9 @@ task(console, dependsOn: 'classes', type: JavaExec) {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
+        events('passed', 'skipped', 'failed')
         exceptionFormat = 'full'
         showStandardStreams = true
     }

--- a/jsx-asset-pipeline/build.gradle
+++ b/jsx-asset-pipeline/build.gradle
@@ -44,20 +44,16 @@ java {
 }
 
 dependencies {
+
     api project(':asset-pipeline-core')
-    compileOnly 'org.apache.groovy:groovy:4.0.22'
-    compileOnly 'org.mozilla:rhino:1.7R4'
-    compileOnly "org.graalvm.sdk:graal-sdk:$graalvmVersion"
-    compileOnly "org.graalvm.js:js-community:$graalvmVersion"
-    compileOnly "org.graalvm.js:js-scriptengine:$graalvmVersion"
 
+    // Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
+    compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+    compileOnly "org.graalvm.polyglot:polyglot:$graalvmVersion"
 
-    testImplementation 'org.mozilla:rhino:1.7R4'
-    testImplementation "org.graalvm.sdk:graal-sdk:$graalvmVersion"
+    testImplementation "org.apache.groovy:groovy:$groovy4Version"
     testImplementation "org.graalvm.js:js-community:$graalvmVersion"
-    testImplementation "org.graalvm.js:js-scriptengine:$graalvmVersion"
-    testImplementation 'org.apache.groovy:groovy-all:4.0.22'
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    testImplementation "org.spockframework:spock-core:$spockVersion"
 }
 
 publishing {

--- a/jsx-asset-pipeline/build.gradle
+++ b/jsx-asset-pipeline/build.gradle
@@ -47,15 +47,15 @@ dependencies {
     api project(':asset-pipeline-core')
     compileOnly 'org.apache.groovy:groovy:4.0.22'
     compileOnly 'org.mozilla:rhino:1.7R4'
-    compileOnly("org.graalvm.sdk:graal-sdk:$graalvmVersion")
-    compileOnly("org.graalvm.js:js:$graalvmVersion")
-    compileOnly("org.graalvm.js:js-scriptengine:$graalvmVersion")
+    compileOnly "org.graalvm.sdk:graal-sdk:$graalvmVersion"
+    compileOnly "org.graalvm.js:js-community:$graalvmVersion"
+    compileOnly "org.graalvm.js:js-scriptengine:$graalvmVersion"
 
 
     testImplementation 'org.mozilla:rhino:1.7R4'
-    testImplementation("org.graalvm.sdk:graal-sdk:$graalvmVersion")
-    testImplementation("org.graalvm.js:js:$graalvmVersion")
-    testImplementation("org.graalvm.js:js-scriptengine:$graalvmVersion")
+    testImplementation "org.graalvm.sdk:graal-sdk:$graalvmVersion"
+    testImplementation "org.graalvm.js:js-community:$graalvmVersion"
+    testImplementation "org.graalvm.js:js-scriptengine:$graalvmVersion"
     testImplementation 'org.apache.groovy:groovy-all:4.0.22'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
 }

--- a/jsx-asset-pipeline/build.gradle
+++ b/jsx-asset-pipeline/build.gradle
@@ -47,15 +47,15 @@ dependencies {
     api project(':asset-pipeline-core')
     compileOnly 'org.apache.groovy:groovy:4.0.22'
     compileOnly 'org.mozilla:rhino:1.7R4'
-    compileOnly("org.graalvm.sdk:graal-sdk:22.0.0.2")
-    compileOnly("org.graalvm.js:js:22.0.0.2")
-    compileOnly("org.graalvm.js:js-scriptengine:22.0.0.2")
+    compileOnly("org.graalvm.sdk:graal-sdk:$graalvmVersion")
+    compileOnly("org.graalvm.js:js:$graalvmVersion")
+    compileOnly("org.graalvm.js:js-scriptengine:$graalvmVersion")
 
 
     testImplementation 'org.mozilla:rhino:1.7R4'
-    testImplementation("org.graalvm.sdk:graal-sdk:22.0.0.2")
-    testImplementation("org.graalvm.js:js:22.0.0.2")
-    testImplementation("org.graalvm.js:js-scriptengine:22.0.0.2")
+    testImplementation("org.graalvm.sdk:graal-sdk:$graalvmVersion")
+    testImplementation("org.graalvm.js:js:$graalvmVersion")
+    testImplementation("org.graalvm.js:js-scriptengine:$graalvmVersion")
     testImplementation 'org.apache.groovy:groovy-all:4.0.22'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
 }

--- a/less-asset-pipeline/build.gradle
+++ b/less-asset-pipeline/build.gradle
@@ -113,12 +113,3 @@ task(console, dependsOn: 'classes', type: JavaExec) {
   main = 'groovy.ui.Console'
   classpath = sourceSets.main.runtimeClasspath
 }
-
-test {
-    testLogging {
-        exceptionFormat = 'full'
-        showStandardStreams = true
-    }
-}
-
-

--- a/less-asset-pipeline/build.gradle
+++ b/less-asset-pipeline/build.gradle
@@ -43,14 +43,19 @@ sourceSets {
 }
 
 dependencies {
-    compileOnly 'org.apache.groovy:groovy-all:4.0.22'
-    api project(':asset-pipeline-core')
-    api 'org.mozilla:rhino:1.7R4'
-    api 'org.slf4j:slf4j-api:1.7.28'
-    api "com.github.sommeri:less4j:1.17.2"
-    api "com.github.sommeri:less4j-javascript:0.0.1"
 
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    api project(':asset-pipeline-core')
+    api "org.mozilla:rhino:$rhinoVersion"
+    api "com.github.sommeri:less4j:$less4jVersion"
+
+    implementation "com.github.sommeri:less4j-javascript:$less4jJsVersion", {
+        // An old forked version of Rhino is included in less4j-javascript
+        exclude group: 'ro.isdc.wro4j', module: 'rhino'
+    }
+
+    // Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
+    compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+    compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
 }
 
 publishing {

--- a/sass-asset-pipeline/assets/stylesheets/webjar-import/main.scss
+++ b/sass-asset-pipeline/assets/stylesheets/webjar-import/main.scss
@@ -1,1 +1,1 @@
-@import "/webjars/bootstrap/5.1.3/scss/bootstrap";
+@import "/webjars/bootstrap/5.3.3/scss/bootstrap";

--- a/sass-asset-pipeline/build.gradle
+++ b/sass-asset-pipeline/build.gradle
@@ -42,17 +42,19 @@ java {
 }
 
 dependencies {
-    compileOnly 'org.apache.groovy:groovy-all:4.0.22'
+
 	api project(':asset-pipeline-core')
-    api 'org.slf4j:slf4j-api:1.7.28'
-    api 'io.bit3:jsass:5.11.1'
-    api group: 'org.sharegov', name: 'mjson', version: '1.4.1'
+    api "io.bit3:jsass:$jsassVersion"
 
-    testImplementation 'org.apache.groovy:groovy-all:4.0.22'
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    // Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
+    compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+    compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.21'
-    testRuntimeOnly 'org.webjars:bootstrap:5.1.3'
+    testImplementation "org.apache.groovy:groovy:$groovy4Version"
+    testImplementation "org.spockframework:spock-core:$spockVersion"
+
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
+    testRuntimeOnly "org.webjars:bootstrap:$bootstrapCssVersion"
 }
 
 publishing {

--- a/sass-asset-pipeline/build.gradle
+++ b/sass-asset-pipeline/build.gradle
@@ -113,7 +113,9 @@ task(console, dependsOn: 'classes', type: JavaExec) {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
+        events('passed', 'skipped', 'failed')
         exceptionFormat = 'full'
         showStandardStreams = true
     }

--- a/sass-asset-pipeline/src/test/groovy/asset/pipeline/jsass/SassProcessorSpec.groovy
+++ b/sass-asset-pipeline/src/test/groovy/asset/pipeline/jsass/SassProcessorSpec.groovy
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 the original author or authors.
+* Copyright 2014-2025 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -105,6 +105,6 @@ class SassProcessorSpec extends Specification {
 		when:
 		def output = processor.process(assetFile.inputStream.text,assetFile)
 		then:
-		output.contains('Twitter')
+		output.contains('https://getbootstrap.com')
 	}
 }

--- a/sass-dart-asset-pipeline/assets/stylesheets/webjar-import/main.scss
+++ b/sass-dart-asset-pipeline/assets/stylesheets/webjar-import/main.scss
@@ -1,1 +1,1 @@
-@import "/webjars/bootstrap/5.1.3/scss/bootstrap";
+@import "/webjars/bootstrap/5.3.3/scss/bootstrap";

--- a/sass-dart-asset-pipeline/build.gradle
+++ b/sass-dart-asset-pipeline/build.gradle
@@ -136,7 +136,9 @@ task(console, dependsOn: 'classes', type: JavaExec) {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
+        events('passed', 'skipped', 'failed')
         exceptionFormat = 'full'
         showStandardStreams = true
     }

--- a/sass-dart-asset-pipeline/build.gradle
+++ b/sass-dart-asset-pipeline/build.gradle
@@ -19,7 +19,6 @@ sourceCompatibility = '1.17'
 targetCompatibility = '1.17'
 
 ext {
-    javetVersion = "1.1.0"
     isReleaseVersion = !version.endsWith("SNAPSHOT")
 }
 
@@ -49,16 +48,19 @@ java {
 apply plugin: 'com.github.node-gradle.node'
 
 dependencies {
-    implementation 'org.apache.groovy:groovy-all:4.0.22'
-    implementation "com.caoccao.javet:javet-core:${javetVersion}"
+
     api project(':asset-pipeline-core')
-    api 'org.slf4j:slf4j-api:1.7.28'
-    testImplementation 'org.apache.groovy:groovy-all:4.0.22'
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
 
-    testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.21'
-    testRuntimeOnly 'org.webjars:bootstrap:5.1.3'
+    implementation "com.caoccao.javet:javet-core:$javetVersion"
 
+    compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+    compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
+
+    testImplementation "org.apache.groovy:groovy:$groovy4Version"
+    testImplementation "org.spockframework:spock-core:$spockVersion"
+
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
+    testRuntimeOnly "org.webjars:bootstrap:$bootstrapCssVersion"
 }
 
 publishing {

--- a/sass-dart-asset-pipeline/src/test/groovy/asset/pipeline/dart/SassProcessorSpec.groovy
+++ b/sass-dart-asset-pipeline/src/test/groovy/asset/pipeline/dart/SassProcessorSpec.groovy
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 the original author or authors.
+* Copyright 2014-2025 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -128,6 +128,6 @@ class SassProcessorSpec extends Specification {
 		when:
 		def output = processor.process(assetFile.inputStream.text,assetFile)
 		then:
-		output.contains('Twitter')
+		output.contains('https://getbootstrap.com')
 	}
 }


### PR DESCRIPTION
This addresses 
```
java.lang.ClassNotFoundException: org.graalvm.polyglot.Context
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
```

This exception occurs because `org.graalvm.polyglot:polyglot` is not present in the classpath, but this is expected because that dependency is not part of graalvm 22.0.0.2.   So if an application is using a later version of graalvm, they will get an exception asset-pipeline-gradle uses 22.0.0.2 **and** the plugin does not automatically look for an include the polygot dependency. 

Currently, dependencies are added to the bootRun task if the dependency starts with a particular string, but this is actually resulting in unwanted dependencies being added such as findbugs jsr305  and jspecify which aren't even needed simply because `file.name.startsWith('js')`.

https://github.com/bertramdev/asset-pipeline/blob/905f3992c83c2193954348e2feefc14bb016c7ea/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy#L167-L169

All these things are done in the background and there is no way to know that they are being resolved in the final bootRun classpath. 

This PR simplifies everything, makes it more maintainable, and provides better exposure to understand what exactly is being added to the bootRun classpath.

1. It simply adds the asset-pipeline-gradle plugin as a dependency to bootRun and provide a mechanism for listing the resolved dependencies which are those propagated through the api scope.  If more dependencies are needed, they can be added as api to the asset-pipeline-gradle project.  
```
gradle dependencies --configuration assetDevelopmentRuntime

assetDevelopmentRuntime
\--- com.bertramlabs.plugins:asset-pipeline-gradle:5.0.6
     +--- com.bertramlabs.plugins:asset-pipeline-core:5.0.6
     |    \--- org.slf4j:slf4j-api:1.7.28 -> 2.0.16
     +--- com.google.javascript:closure-compiler-unshaded:v20240317
     |    +--- args4j:args4j:2.33
     |    +--- com.google.code.gson:gson:2.9.1 -> 2.11.0
     |    |    \--- com.google.errorprone:error_prone_annotations:2.27.0 -> 2.28.0
     |    +--- com.google.errorprone:error_prone_annotations:2.18.0 -> 2.28.0
     |    +--- com.google.guava:failureaccess:1.0.1 -> 1.0.2
     |    +--- com.google.guava:guava:32.1.2-jre -> 33.3.1-jre
     |    |    +--- com.google.guava:failureaccess:1.0.2
     |    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     |    |    +--- com.google.code.findbugs:jsr305:3.0.2
     |    |    +--- org.checkerframework:checker-qual:3.43.0
     |    |    +--- com.google.errorprone:error_prone_annotations:2.28.0
     |    |    \--- com.google.j2objc:j2objc-annotations:3.0.0
     |    +--- com.google.protobuf:protobuf-java:3.21.12
     |    +--- com.google.re2j:re2j:1.3
     |    \--- org.jspecify:jspecify:0.2.0 -> 1.0.0
     +--- org.graalvm.sdk:graal-sdk:24.1.2
     |    +--- org.graalvm.sdk:collections:24.1.2
     |    +--- org.graalvm.sdk:nativeimage:24.1.2
     |    |    \--- org.graalvm.sdk:word:24.1.2
     |    +--- org.graalvm.polyglot:polyglot:24.1.2
     |    |    +--- org.graalvm.sdk:collections:24.1.2
     |    |    \--- org.graalvm.sdk:nativeimage:24.1.2 (*)
     |    \--- org.graalvm.sdk:word:24.1.2
     +--- org.graalvm.js:js:24.1.2
     |    \--- org.graalvm.truffle:truffle-enterprise:24.1.2
     |         +--- org.graalvm.truffle:truffle-compiler:24.1.2
     |         +--- org.graalvm.truffle:truffle-runtime:24.1.2
     |         |    +--- org.graalvm.sdk:jniutils:24.1.2
     |         |    |    +--- org.graalvm.sdk:collections:24.1.2
     |         |    |    \--- org.graalvm.sdk:nativeimage:24.1.2 (*)
     |         |    +--- org.graalvm.truffle:truffle-api:24.1.2
     |         |    |    +--- org.graalvm.sdk:collections:24.1.2
     |         |    |    +--- org.graalvm.sdk:nativeimage:24.1.2 (*)
     |         |    |    \--- org.graalvm.polyglot:polyglot:24.1.2 (*)
     |         |    \--- org.graalvm.truffle:truffle-compiler:24.1.2
     |         +--- org.graalvm.sdk:jniutils:24.1.2 (*)
     |         \--- org.graalvm.sdk:nativebridge:24.1.2
     |              \--- org.graalvm.sdk:jniutils:24.1.2 (*)
     +--- org.graalvm.js:js-language:24.1.2
     |    +--- org.graalvm.regex:regex:24.1.2
     |    |    +--- org.graalvm.truffle:truffle-api:24.1.2 (*)
     |    |    \--- org.graalvm.shadowed:icu4j:24.1.2
     |    +--- org.graalvm.truffle:truffle-api:24.1.2 (*)
     |    +--- org.graalvm.polyglot:polyglot:24.1.2 (*)
     |    \--- org.graalvm.shadowed:icu4j:24.1.2
     \--- org.graalvm.js:js-scriptengine:24.1.2
          \--- org.graalvm.polyglot:polyglot:24.1.2 (*)
```

2. asset dependencies are also added and can be listed via the assets configuration
```
gradle dependencies --configuration assets 

assets
\--- com.bertramlabs.plugins:less-asset-pipeline:5.0.6
     +--- com.bertramlabs.plugins:asset-pipeline-core:5.0.6
     |    \--- org.slf4j:slf4j-api:1.7.28 -> 2.0.16
     +--- org.mozilla:rhino:1.7R4
     +--- org.slf4j:slf4j-api:1.7.28 -> 2.0.16
     +--- com.github.sommeri:less4j:1.17.2
     |    +--- org.antlr:antlr-runtime:3.5.2
     |    +--- commons-io:commons-io:2.3
     |    +--- commons-beanutils:commons-beanutils:1.8.3
     |    |    \--- commons-logging:commons-logging:1.1.1
     |    +--- com.google.code.gson:gson:2.5 -> 2.11.0
     |    |    \--- com.google.errorprone:error_prone_annotations:2.27.0
     |    \--- com.google.protobuf:protobuf-java:2.5.0
     \--- com.github.sommeri:less4j-javascript:0.0.1
          +--- junit:junit:4.11 -> 4.13.2
          |    \--- org.hamcrest:hamcrest-core:1.3 -> 2.2
          |         \--- org.hamcrest:hamcrest:2.2
          +--- com.github.sommeri:less4j:1.5.2 -> 1.17.2 (*)
          \--- ro.isdc.wro4j:rhino:1.7R5-20130223-1
```

3. updates graalvm to `24.1.2`
4. updates gradle to `8.12.1`


### Pros
Simple
Makes class path resolution understood
Simplifies code
Imports dependencies as expected
Allows maintaining of dependencies via `build.gradle`

### Cons
Adds a single gradle plugin `asset-pipeline-gradle` jar to the bootRun classpath, but this has the added advantage of not needing to hard code graalvm versions inside the plugin code. 