### PR TITLE
Improve Compatibility with `bootTestRun` and `JavaPlugin`

### DIFF
--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -35,11 +35,11 @@ java {
 
 dependencies {
 
-    implementation gradleApi()
     implementation project(':asset-pipeline-core')
 
     // Gradle Plugin must be compiled with Groovy 3
     compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
+    compileOnly gradleApi()
 
     // These will be used by the Asset Pipeline Gradle Plugin for pre-compiling assets
     // and when running bootRun task (in development)

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -43,7 +43,7 @@ class AssetPipelinePlugin implements Plugin<Project> {
     static final String ASSET_DEVELOPMENT_CONFIGURATION_NAME = 'assetDevelopmentRuntime'
 
     void apply(Project project) {
-        createGradleConfiguration(project)
+        createAssetsGradleConfiguration(project)
 
         def defaultConfiguration = project.extensions.create('assets', AssetPipelineExtensionImpl)
         def config = AssetPipelineConfigHolder.config != null ? AssetPipelineConfigHolder.config : [:]
@@ -153,8 +153,12 @@ class AssetPipelinePlugin implements Plugin<Project> {
         }
     }
 
-    private void createGradleConfiguration(Project project) {
+    private void createAssetsGradleConfiguration(Project project) {
         Configuration assetsConfiguration = project.configurations.create(ASSET_CONFIGURATION_NAME)
-        project.configurations.getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME).extendsFrom(assetsConfiguration)
+        project.plugins.withType(JavaPlugin).configureEach {
+            project.configurations.named(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).configure {
+                it.extendsFrom(assetsConfiguration)
+            }
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.0.6
+version=5.0.7
 
 bootstrapCssVersion=5.3.3
 closureCompilerVersion=v20240317


### PR DESCRIPTION
This PR includes three key fixes:

- `bootTestRun` classpath fix:
Ensures that necessary classes are added to the `bootTestRun` classpath, aligning its behavior with `bootRun`.

- `JavaPlugin` compatibility:
Restores the ability to apply this plugin before the `JavaPlugin` in the build script, ensuring proper compatibility and plugin order flexibility.

- Remove `grailsApi()` dependency from `bootRun` runtime classpath.

For detailed explanations, please refer to the individual commit messages.