### PR TITLE
fix: Add necessary asset compiler classes to the `testRuntimeOnly` configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.0.7
+version=5.0.8
 
 bootstrapCssVersion=5.3.3
 closureCompilerVersion=v20240317


### PR DESCRIPTION
We have previously added these classes to the runtime classpath of `bootRun` and `bootTestRun` (which made it work in development).

However, when running integration tests in Grails, these tasks are not used.
This commit adds the classes to the `testRuntimeOnly` (from the `JavaPlugin`) which is extended by the `integrationTestRuntimeOnly` configuration from `GrailsGradlePlugin`.

If we don't do this, projects with assets will need to explicitly add `org.graalvm.js:js-community` to the `integrationTestRuntimeOnly` configuration for assets to be able to compile during test execution.