### PR TITLE
Fix: return eTag with 304 responses

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetPipelineResponseBuilder.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetPipelineResponseBuilder.groovy
@@ -65,11 +65,12 @@ public class AssetPipelineResponseBuilder {
 
     public Boolean checkETag() {
         String etagName = getCurrentETag()
+        headers["ETag"] = etagName
+
         if (ifNoneMatchHeader && ifNoneMatchHeader == etagName) {
             statusCode = 304
             return false
         }
-        headers["ETag"] = etagName
         return true
     }
 

--- a/asset-pipeline-core/src/test/groovy/asset/pipeline/AssetPipelineResponseBuilderSpec.groovy
+++ b/asset-pipeline-core/src/test/groovy/asset/pipeline/AssetPipelineResponseBuilderSpec.groovy
@@ -43,4 +43,28 @@ public class AssetPipelineResponseBuilderSpec extends Specification {
         filename << ['header.js', '/header.js']
     }
 
+    @Unroll
+    def "make sure etag is set for 304 reponse"() {
+        given:
+        Properties props = new Properties()
+        props.setProperty("global.js", "global-1d9c55a6d7ec00ec71a5aee2b8749d28.js")
+        AssetPipelineConfigHolder.setManifest(props)
+        AssetPipelineResponseBuilder aprb = new AssetPipelineResponseBuilder(filename)
+
+        aprb.ifNoneMatchHeader = "\"global-1d9c55a6d7ec00ec71a5aee2b8749d28.js\""
+        aprb.headers = [:]
+        aprb.statusCode = 200
+
+        when:
+        def result = aprb.checkETag()
+
+        then:
+        aprb.headers.get('ETag') == "\"global-1d9c55a6d7ec00ec71a5aee2b8749d28.js\""
+        aprb.statusCode == 304
+        result == false
+
+        where:
+        filename << ['global.js', '/global.js']
+    }
+
 }


### PR DESCRIPTION
This pull request adds an ETag to the response headers for 304 Not Modified responses, as specified by [RFC 9110, Section 15.4.5](https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified)
> The server generating a 304 response MUST generate any of the following header fields that would have been sent in a [200 (OK)](https://www.rfc-editor.org/rfc/rfc9110.html#status.200) response to the same request:
> * [Content-Location](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-location), [Date](https://www.rfc-editor.org/rfc/rfc9110.html#field.date), [ETag](https://www.rfc-editor.org/rfc/rfc9110.html#field.etag), and [Vary](https://www.rfc-editor.org/rfc/rfc9110.html#field.vary)

Including the ETag in these responses helps clients validate cached content correctly and reduces unnecessary data transfers. 
This change brings the implementation more in line with HTTP standards.